### PR TITLE
Fix README prerequisites, setup order, and entry point docs

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -2,6 +2,11 @@
 
 A retail inventory management app for Android demonstrating Couchbase Lite's offline-first capabilities, real-time sync with Capella App Services, and peer-to-peer sync between devices.
 
+## Prerequisites
+
+> [!IMPORTANT]
+> Before proceeding with the Android setup, you **must** complete the Capella backend configuration described in the [root README](../README.md). This includes creating a Capella cluster, deploying an App Service, setting up the bucket/scopes/collections, importing the sample dataset, creating App Endpoints and App Users, and recording the public connection URL. If you skip these steps, the app will fail to authenticate and sync.
+
 ## Quick Start (For Already Configured Systems)
 
 If you've already completed the initial setup and have Java 17 + Couchbase Lite EE installed:
@@ -138,6 +143,8 @@ This may take a few minutes on first open.
 ### 3. Configure Capella App Services
 
 Before running the app, configure your Capella App Services connection using environment variables or Gradle properties.
+
+**Where to find `CBL_BASE_URL`**: In your Capella dashboard, go to **App Services** > select your App Endpoint (e.g. `supermarket-nyc`) > **Connect** tab. Copy the **Public Connection URL** — it will look like `wss://<id>.apps.cloud.couchbase.com:4984`. Use only the base URL; do **not** append the database name (that is handled separately by `CBL_AA_DB` / `CBL_NYC_DB`).
 
 #### Option A: Environment Variables (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,17 @@ These are common set of instructions that you must follow to setup the cloud bac
 Although instructions are specified for Capella App Services, equivalent instructions apply to self-managed Sync Gateway as well. 
 
 - Create a couchbase cluster on Capella by following these [instructions](https://docs.couchbase.com/cloud/get-started/create-account.html).
+
+### Deploy App Service (do this early — it takes 5–25 minutes)
+
+> [!TIP]
+> App Service deployments can take between 5 and 25 minutes. Start the deployment now so it can provision in the background while you set up the bucket, scopes, collections, and sample data in the steps that follow.
+
+- Create an App Service named **"supermarket-appservice"** (you can name it anything) that is linked to the cluster you just created by following these [instructions](https://docs.couchbase.com/cloud/get-started/create-account.html#app-services)
+
+### Create Bucket, Scopes and Collections
   
-- Create a bucket named **"supermarket"** cluster on Capella by following these [instructions](https://docs.couchbase.com/cloud/clusters/data-service/about-buckets-scopes-collections.html#buckets). 
+- Create a bucket named **"supermarket"** on the cluster by following these [instructions](https://docs.couchbase.com/cloud/clusters/data-service/about-buckets-scopes-collections.html#buckets). 
 
 - Create two scopes named **"NYC-Store"** and **"AA-Store"** in the bucket by following these [instructions](https://docs.couchbase.com/cloud/clusters/data-service/about-buckets-scopes-collections.html#scopes). 
 
@@ -50,8 +59,9 @@ Although instructions are specified for Capella App Services, equivalent instruc
 
 ![](./common/assets/import-data.png)
 
-## Setting up Capella App Services
-- Create an App Service named **"supermarket-appservice"** (you can name it anything) that is linked to the supermarket cluster by following these [instructions](https://docs.couchbase.com/cloud/get-started/create-account.html#app-services) 
+## Configuring Capella App Services
+
+By now your App Service deployment (started earlier) should be ready or close to ready.
 
 - Create two App Endpoints corresponding to the two scopes. This is an example for AA store. Name App Endpoints as **"supermarket-aa"** and **"supermarket-nyc"** by following these [instructions](https://docs.couchbase.com/cloud/get-started/configuring-app-services.html#create-app-endpoint).
 

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -30,7 +30,7 @@ The project uses Swift Package Manager (SPM) for dependency management. Dependen
 > unable to read input file '.../GroceryApp/Info.plist': Operation not permitted
 > ```
 
-Create the file at `iOS/GroceryApp/Info.plist` with your Capella App Services credentials:
+Create the file at `GroceryApp/Info.plist` with your Capella App Services credentials:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -102,7 +102,7 @@ open GroceryApp.xcodeproj
    - `CBL_PASSWORD`: `P@ssword1`
 
 > [!NOTE]
-> An `Info.plist` file is still required for the build to succeed, even when using environment variables. You can create a minimal empty plist if you prefer to configure credentials via environment variables only.
+> An `Info.plist` file is still required for the build to succeed, even when using environment variables. You can create a minimal **valid** plist (containing a root dict) if you prefer to configure credentials via environment variables only.
 
 ### 4. Build and Run
 

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -2,6 +2,11 @@
 
 A retail inventory management app for iOS demonstrating Couchbase Lite's offline-first capabilities, real-time sync with Capella App Services, and peer-to-peer sync between devices.
 
+## Prerequisites
+
+> [!IMPORTANT]
+> Before proceeding with the iOS setup, you **must** complete the Capella backend configuration described in the [root README](../README.md). This includes creating a Capella cluster, deploying an App Service, setting up the bucket/scopes/collections, importing the sample dataset, creating App Endpoints and App Users, and recording the public connection URL. If you skip these steps, the app will fail to authenticate and sync.
+
 ## Requirements
 
 - **Xcode**: 16.4 or later
@@ -17,7 +22,40 @@ The project uses Swift Package Manager (SPM) for dependency management. Dependen
 
 ## Getting Started
 
-### 1. Open the Project
+### 1. Create Info.plist (Required Before Building)
+
+> [!IMPORTANT]
+> `Info.plist` is **not** included in the repository but is required by the Xcode project. You must create it before attempting to build, or the build will fail with:
+> ```
+> unable to read input file '.../GroceryApp/Info.plist': Operation not permitted
+> ```
+
+Create the file at `iOS/GroceryApp/Info.plist` with your Capella App Services credentials:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CBL_BASE_URL</key>
+    <string>wss://your-endpoint.apps.cloud.couchbase.com:4984</string>
+    <key>CBL_AA_DB</key>
+    <string>supermarket-aa</string>
+    <key>CBL_NYC_DB</key>
+    <string>supermarket-nyc</string>
+    <key>CBL_AA_USER</key>
+    <string>aa-store-01@supermarket.com</string>
+    <key>CBL_NYC_USER</key>
+    <string>nyc-store-01@supermarket.com</string>
+    <key>CBL_PASSWORD</key>
+    <string>P@ssword1</string>
+</dict>
+</plist>
+```
+
+**Where to find `CBL_BASE_URL`**: In your Capella dashboard, go to **App Services** > select your App Endpoint (e.g. `supermarket-nyc`) > **Connect** tab. Copy the **Public Connection URL** — it will look like `wss://<id>.apps.cloud.couchbase.com:4984`. Use only the base URL; do **not** append the database name (that is handled separately by `CBL_AA_DB` / `CBL_NYC_DB`).
+
+### 2. Open the Project
 
 Open the Xcode project:
 
@@ -28,26 +66,11 @@ open GroceryApp.xcodeproj
 
 Xcode will automatically resolve and download the required Swift packages when you first open the project.
 
-### 2. Configure Capella App Services
+### 3. Configure Capella App Services (Alternative Methods)
 
-Before running the app, you need to configure your Capella App Services connection. You have three options:
+If you prefer not to use `Info.plist` for configuration, you have two other options. The app checks environment variables first, then falls back to Info.plist.
 
-#### Option A: Info.plist (Recommended)
-
-Add the configuration values to your `Info.plist` file:
-
-1. Open `GroceryApp/Info.plist` in Xcode
-2. Add the following keys and values:
-   - `CBL_BASE_URL`: `wss://your-endpoint.apps.cloud.couchbase.com:4984`
-   - `CBL_AA_DB`: `supermarket-aa`
-   - `CBL_NYC_DB`: `supermarket-nyc`
-   - `CBL_AA_USER`: `aa-store-01@supermarket.com`
-   - `CBL_NYC_USER`: `nyc-store-01@supermarket.com`
-   - `CBL_PASSWORD`: `P@ssword1`
-
-This is the most common approach for iOS projects and keeps configuration in a standard location.
-
-#### Option B: Environment Variables (Terminal Launch)
+#### Option A: Environment Variables (Terminal Launch)
 
 Set environment variables in your shell:
 
@@ -66,7 +89,7 @@ Then launch Xcode from the terminal to inherit these variables:
 open GroceryApp.xcodeproj
 ```
 
-#### Option C: Xcode Scheme Configuration
+#### Option B: Xcode Scheme Configuration
 
 1. In Xcode, select **Product** > **Scheme** > **Edit Scheme**
 2. Go to **Run** > **Arguments** tab
@@ -78,10 +101,10 @@ open GroceryApp.xcodeproj
    - `CBL_NYC_USER`: `nyc-store-01@supermarket.com`
    - `CBL_PASSWORD`: `P@ssword1`
 
-**Note**: The app checks environment variables first, then falls back to Info.plist. Choose whichever method works best for your workflow.
+> [!NOTE]
+> An `Info.plist` file is still required for the build to succeed, even when using environment variables. You can create a minimal empty plist if you prefer to configure credentials via environment variables only.
 
-
-### 3. Build and Run
+### 4. Build and Run
 
 Select a simulator or connected device and click **Run** (⌘R).
 
@@ -90,7 +113,8 @@ Select a simulator or connected device and click **Run** (⌘R).
 ```
 iOS/
 ├── GroceryApp/
-│   ├── App.swift                        # Main app entry point
+│   ├── GroceryAppApp.swift              # Main app entry point (@main)
+│   ├── App.swift                        # P2P sync helper (GrocerySyncApp, Network Framework)
 │   ├── AppConfig.swift                  # Configuration (database, sync, stores)
 │   ├── DatabaseManager.swift            # Couchbase Lite database operations
 │   ├── AppServicesSyncManager.swift     # Sync with Capella App Services

--- a/web/README.md
+++ b/web/README.md
@@ -22,6 +22,9 @@ A modern retail inventory management application built with Couchbase Lite for w
 
 ## Prerequisites
 
+> [!IMPORTANT]
+> Before proceeding with the web app setup, you **must** complete the Capella backend configuration described in the [root README](../README.md). This includes creating a Capella cluster, deploying an App Service, setting up the bucket/scopes/collections, importing the sample dataset, creating App Endpoints and App Users, recording the public connection URL, and configuring CORS for the web app. If you skip these steps, the app will fail to authenticate and sync.
+
 - **Node.js**: Version 18 or higher ([install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating))
 - **npm**: Comes with Node.js
 - **Couchbase Capella Account**: For App Services sync functionality


### PR DESCRIPTION
Addresses #13, #16, #17, #18, #19

Reorder global README to deploy App Service early (saves 5–25 min wait)
iOS: Add Info.plist creation as a required step before building
iOS: Add prerequisites section linking to root README for Capella setup
iOS: Explain where to find CBL_BASE_URL (Capella Connect tab)
iOS: Fix App.swift entry point — GroceryAppApp.swift is @main
Android/Web: Add same prerequisites section and CBL_BASE_URL guidance