### PR TITLE
fix(ios): dynamic store selection based on authenticated user

### DIFF
--- a/iOS/GroceryApp/AppConfig.swift
+++ b/iOS/GroceryApp/AppConfig.swift
@@ -17,18 +17,17 @@ enum StoreLocation: String, CaseIterable {
 struct AppConfig {
     
     // MARK: - Current Store Selection
-    // Change this value to switch between stores
-    static let currentStore: StoreLocation = .nyc
+    // Set at runtime after login based on authenticated user
+    static var currentStore: StoreLocation = .nyc
     
     // MARK: - Capella App Services Configuration (ENV/Info.plist DRIVEN)
-    // Prefer Info.plist (via .xcconfig) or environment variables when running from Xcode
-    private static let env = ProcessInfo.processInfo.environment
-    private static let baseURL: String = env["CBL_BASE_URL"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_BASE_URL") as? String ?? "")
-    private static let aaDB: String = env["CBL_AA_DB"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_AA_DB") as? String ?? "")
-    private static let nycDB: String = env["CBL_NYC_DB"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_NYC_DB") as? String ?? "")
-    private static let aaUser: String = env["CBL_AA_USER"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_AA_USER") as? String ?? "")
-    private static let nycUser: String = env["CBL_NYC_USER"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_NYC_USER") as? String ?? "")
-    private static let passwordValue: String = env["CBL_PASSWORD"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_PASSWORD") as? String ?? "")
+    // Prefer environment variables, then Info.plist — computed each time to avoid lazy init caching empty values
+    private static var baseURL: String { ProcessInfo.processInfo.environment["CBL_BASE_URL"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_BASE_URL") as? String ?? "") }
+    private static var aaDB: String { ProcessInfo.processInfo.environment["CBL_AA_DB"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_AA_DB") as? String ?? "") }
+    private static var nycDB: String { ProcessInfo.processInfo.environment["CBL_NYC_DB"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_NYC_DB") as? String ?? "") }
+    private static var aaUser: String { ProcessInfo.processInfo.environment["CBL_AA_USER"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_AA_USER") as? String ?? "") }
+    private static var nycUser: String { ProcessInfo.processInfo.environment["CBL_NYC_USER"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_NYC_USER") as? String ?? "") }
+    private static var passwordValue: String { ProcessInfo.processInfo.environment["CBL_PASSWORD"] ?? (Bundle.main.object(forInfoDictionaryKey: "CBL_PASSWORD") as? String ?? "") }
     
     static var syncGatewayURL: String {
         switch currentStore {

--- a/iOS/GroceryApp/AuthenticationManager.swift
+++ b/iOS/GroceryApp/AuthenticationManager.swift
@@ -78,7 +78,10 @@ class AuthenticationManager: ObservableObject {
                 fullName: userCredentials.fullName,
                 role: userCredentials.role
             )
-            
+
+            // Set store before triggering UI update so views read from the correct scope
+            AppConfig.currentStore = username.contains("aa-store") ? .aa : .nyc
+
             // Update authentication state
             withAnimation(.easeInOut(duration: 0.3)) {
                 self.currentUser = user
@@ -150,21 +153,9 @@ class AuthenticationManager: ObservableObject {
             return
         }
         
-        // Validate that the stored session matches the current store configuration
-        let expectedUsername: String
-        switch AppConfig.currentStore {
-        case .aa:
-            expectedUsername = "aa-store-01@supermarket.com"
-        case .nyc:
-            expectedUsername = "nyc-store-01@supermarket.com"
-        }
-        
-        guard username == expectedUsername else {
-            print("⚠️ Stored session (\(username)) doesn't match current store (\(AppConfig.currentStore.displayName)), clearing session")
-            clearStoredLogin()
-            return
-        }
-        
+        // Set store before restoring session so views read from the correct scope
+        AppConfig.currentStore = username.contains("aa-store") ? .aa : .nyc
+
         // Restore user session
         let user = User(username: username, fullName: fullName, role: role)
         DispatchQueue.main.async {

--- a/iOS/GroceryApp/DatabaseManager.swift
+++ b/iOS/GroceryApp/DatabaseManager.swift
@@ -788,20 +788,37 @@ class DatabaseManager: ObservableObject {
 
     func reconfigure(for store: StoreLocation) {
         print("Reconfiguring DatabaseManager for store: \(store.displayName)")
-        AppConfig.currentStore = store
 
-        collectionChangeListenerToken?.remove()
-        collectionChangeListenerToken = nil
+        // Explicitly stop the replicator before releasing the sync manager so the
+        // old WebSocket connection is closed before the new one starts
+        appServicesSyncManager?.disableAppServices()
         appServicesSyncManager = nil
         isAppServicesEnabled = false
 
+        // Remove change listener before closing the database
+        collectionChangeListenerToken?.remove()
+        collectionChangeListenerToken = nil
+
+        // Close the database so checkAndHandleStoreChange (called inside openDatabase)
+        // can delete old store data if the store has changed
+        do {
+            try database?.close()
+            database = nil
+        } catch {
+            print("Error closing database during reconfigure: \(error)")
+        }
+
+        // Update store then reopen — openDatabase runs checkAndHandleStoreChange
+        // internally, which purges old data when the store differs from last launch
+        AppConfig.currentStore = store
+        openDatabase()
+
+        // Rebuild listeners and sync — no delay needed after synchronous openDatabase()
         setupChangeListeners()
         setupAppServicesIntegration()
 
         if AppConfig.enableAppServicesSync {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.enableAppServices()
-            }
+            enableAppServices()
         }
     }
 

--- a/iOS/GroceryApp/DatabaseManager.swift
+++ b/iOS/GroceryApp/DatabaseManager.swift
@@ -784,8 +784,29 @@ class DatabaseManager: ObservableObject {
         }
     }
     
+    // MARK: - Store Reconfiguration
+
+    func reconfigure(for store: StoreLocation) {
+        print("Reconfiguring DatabaseManager for store: \(store.displayName)")
+        AppConfig.currentStore = store
+
+        collectionChangeListenerToken?.remove()
+        collectionChangeListenerToken = nil
+        appServicesSyncManager = nil
+        isAppServicesEnabled = false
+
+        setupChangeListeners()
+        setupAppServicesIntegration()
+
+        if AppConfig.enableAppServicesSync {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.enableAppServices()
+            }
+        }
+    }
+
     // MARK: - App Services Integration
-    
+
     private func setupAppServicesIntegration() {
         guard let database = database else {
             print("❌ Database not ready for App Services integration")

--- a/iOS/GroceryApp/GroceryAppApp.swift
+++ b/iOS/GroceryApp/GroceryAppApp.swift
@@ -49,6 +49,11 @@ struct GroceryAppApp: App {
                 }
             }
             .animation(.easeInOut(duration: 0.3), value: authManager.isAuthenticated)
+            .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+                guard isAuthenticated, let username = authManager.currentUser?.username else { return }
+                let store: StoreLocation = username.contains("aa-store") ? .aa : .nyc
+                databaseManager.reconfigure(for: store)
+            }
         }
     }
     


### PR DESCRIPTION
## Summary

- `AppConfig.currentStore` was hardcoded to `.nyc` as a `static let`, causing all inventory changes, collection queries, and the App Services replicator to always target the NYC scope regardless of which store account was logged in
- Store is now a `static var` derived from the authenticated username and set before the UI renders, ensuring the correct scope is used from the first data read
- Added `reconfigure(for:)` to `DatabaseManager` to rebuild the change listener and App Services sync manager for the correct store after login
- Removed a session-validation check in `AuthenticationManager` that incorrectly cleared valid AA store sessions on startup (it compared the stored username against `AppConfig.currentStore` which was always `.nyc` at launch)

## Test plan

- [ ] Log in as `aa-store-01@supermarket.com` — inventory and profile should show AA store data
- [ ] Log in as `nyc-store-01@supermarket.com` — inventory and profile should show NYC store data
- [ ] Inventory changes made while logged into AA store should sync to the AA scope, not NYC
- [ ] Session restore on relaunch should load the correct store without requiring re-login