### PR TITLE
fix(android): replace deprecated Couchbase Lite and Compose APIs (fix…

### DIFF
--- a/Android/app/src/main/java/com/example/groceryapplication/AppServicesSyncManager.kt
+++ b/Android/app/src/main/java/com/example/groceryapplication/AppServicesSyncManager.kt
@@ -68,7 +68,7 @@ class AppServicesSyncManager(
         try {
             // Stop and clean up any existing replicator before reconfiguring
             stopSync()
-            replicatorChangeToken?.let { replicator?.removeChangeListener(it) }
+            replicatorChangeToken?.remove()
             replicator = null
             replicatorChangeToken = null
             
@@ -92,24 +92,28 @@ class AppServicesSyncManager(
             val syncUrl = AppConfig.syncGatewayURL
             Log.d(TAG, "📡 Connecting to: $syncUrl")
             val target = URLEndpoint(URI(syncUrl))
-            
-            // Create replicator configuration
-            val config = ReplicatorConfiguration(target)
-            
+
+            // Build per-collection configurations (CBL 3.1+ replaces the deprecated
+            // ReplicatorConfiguration(endpoint) + addCollection() pattern with a
+            // collection-first constructor that takes a set of CollectionConfigurations).
+            val collectionConfigs = CollectionConfiguration.fromCollections(
+                listOf(inventoryCollection, profileCollection, ordersCollection)
+            )
+
+            // Create replicator configuration with collections and endpoint up-front
+            val config = ReplicatorConfiguration(collectionConfigs, target)
+
             // Configure authentication — read dynamically from AppConfig
             config.authenticator = BasicAuthenticator(AppConfig.username, AppConfig.password.toCharArray())
-            
+
             // Configure replication type and behavior
-            config.replicatorType = AbstractReplicatorConfiguration.ReplicatorType.PUSH_AND_PULL
+            // Use the modern top-level ReplicatorType (the AbstractReplicatorConfiguration.ReplicatorType
+            // enum and the replicatorType property are deprecated aliases).
+            config.type = ReplicatorType.PUSH_AND_PULL
             config.isContinuous = AppConfig.SYNC_CONTINUOUS
             config.heartbeat = AppConfig.SYNC_HEARTBEAT.toInt()
             config.maxAttempts = AppConfig.SYNC_MAX_ATTEMPTS
             config.maxAttemptWaitTime = AppConfig.SYNC_MAX_ATTEMPT_WAIT_TIME.toInt()
-            
-            // Add all collections to replication
-            config.addCollection(inventoryCollection, null)
-            config.addCollection(profileCollection, null)
-            config.addCollection(ordersCollection, null)
             
             // Create replicator
             replicator = Replicator(config)
@@ -540,10 +544,9 @@ class AppServicesSyncManager(
         
         stopSync()
         
-        replicatorChangeToken?.let { token ->
-            replicator?.removeChangeListener(token)
-        }
-        
+        replicatorChangeToken?.remove()
+        replicatorChangeToken = null
+
         replicator = null
     }
 }

--- a/Android/app/src/main/java/com/example/groceryapplication/LandingScreen.kt
+++ b/Android/app/src/main/java/com/example/groceryapplication/LandingScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.filled.Home
@@ -39,7 +39,7 @@ fun LandingScreen(
     val databaseManager = GroceryApplication.databaseManager
     
     val navigationItems = listOf(
-        NavigationItem("inventory", Icons.Default.List, "Inventory"),
+        NavigationItem("inventory", Icons.AutoMirrored.Filled.List, "Inventory"),
         NavigationItem("profile", Icons.Default.Store, "Profile"),
         NavigationItem("orders", Icons.Default.ShoppingCart, "Orders"),
         NavigationItem("settings", Icons.Default.Settings, "Settings")

--- a/Android/app/src/main/java/com/example/groceryapplication/LoginScreen.kt
+++ b/Android/app/src/main/java/com/example/groceryapplication/LoginScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.filled.Visibility
@@ -329,7 +329,7 @@ fun LoginScreen(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
-                            imageVector = Icons.Default.ArrowForward,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                             contentDescription = null,
                             tint = Color.White,
                             modifier = Modifier.size(20.dp)
@@ -536,7 +536,7 @@ fun DemoCredentialsDialog(
                                         )
                                     }
                                     Icon(
-                                        imageVector = Icons.Default.ArrowForward,
+                                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                                         contentDescription = null,
                                         tint = Color(0xFFFD9B0B),
                                         modifier = Modifier.size(16.dp)

--- a/Android/app/src/main/java/com/example/groceryapplication/OrdersScreen.kt
+++ b/Android/app/src/main/java/com/example/groceryapplication/OrdersScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -58,7 +58,7 @@ fun OrdersScreen(
             navigationIcon = {
                 IconButton(onClick = onBackPressed) {
                     Icon(
-                        Icons.Default.ArrowBack, 
+                        Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
                         tint = Color(0xFF007AFF)  // iOS blue
                     )

--- a/Android/app/src/main/java/com/example/groceryapplication/ProfileScreen.kt
+++ b/Android/app/src/main/java/com/example/groceryapplication/ProfileScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -41,7 +41,7 @@ fun ProfileScreen(
             navigationIcon = {
                 IconButton(onClick = onBackPressed) {
                     Icon(
-                        Icons.Default.ArrowBack, 
+                        Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
                         tint = Color(0xFF007AFF)  // iOS blue
                     )

--- a/Android/app/src/main/java/com/example/groceryapplication/SettingsScreen.kt
+++ b/Android/app/src/main/java/com/example/groceryapplication/SettingsScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -69,7 +71,7 @@ fun SettingsScreen(
             navigationIcon = {
                 IconButton(onClick = onBackPressed) {
                     Icon(
-                        Icons.Default.ArrowBack,
+                        Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
                         tint = Color(0xFFFD9B0B)  // Orange color
                     )
@@ -362,7 +364,7 @@ fun SettingsScreen(
                         )
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Logout,
+                            imageVector = Icons.AutoMirrored.Filled.Logout,
                             contentDescription = null,
                             modifier = Modifier.size(20.dp)
                         )


### PR DESCRIPTION
…es #31)

Couchbase Lite (AppServicesSyncManager.kt):
- Replace deprecated ReplicatorConfiguration(endpoint) + addCollection() pattern with the collection-first constructor introduced in CBL 3.1+: ReplicatorConfiguration(CollectionConfiguration.fromCollections(...), endpoint)
- Replace deprecated 'replicatorType = AbstractReplicatorConfiguration.ReplicatorType.X' with the new top-level 'config.type = ReplicatorType.X'
- Replace deprecated Replicator.removeChangeListener(token) calls with ListenerToken.remove() (CBL 3.1+ — ListenerToken is AutoCloseable)

Jetpack Compose (LandingScreen, LoginScreen, OrdersScreen, ProfileScreen, SettingsScreen): migrate Material Icons that have been moved under Icons.AutoMirrored to provide proper RTL support:
- Filled.List → AutoMirrored.Filled.List
- Filled.ArrowForward → AutoMirrored.Filled.ArrowForward
- Filled.ArrowBack → AutoMirrored.Filled.ArrowBack
- Filled.Logout → AutoMirrored.Filled.Logout

Verified with './gradlew clean compileDebugKotlin --warning-mode=all' (zero deprecation warnings) and './gradlew assembleDebug' (BUILD SUCCESSFUL).