### PR TITLE
react-native: extract data hooks, pagination, and visible error states

### DIFF
--- a/react-native/app/(tabs)/index.tsx
+++ b/react-native/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, useCallback, useRef } from 'react';
+import { useContext, useState } from 'react';
 import {
     ActivityIndicator,
     FlatList,
@@ -12,13 +12,15 @@ import {
     Modal,
     Dimensions,
     Image,
+    RefreshControl,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { ThemedSearchBar } from '@/components/searchBar/ThemedSearchBar';
+import { ErrorBanner } from '@/components/feedback/ErrorBanner';
 import DatabaseContext from '@/providers/DatabaseContext';
 import { useAuth } from '@/providers/AuthContext';
 import { GroceryItem, getQuantityColor } from '@/models/GroceryItem';
-import { debounce } from '@/util/debounce';
+import { useInventory } from '@/hooks/useInventory';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const CARD_GAP = 10;
@@ -27,145 +29,50 @@ const CARD_WIDTH = (SCREEN_WIDTH - CARD_PADDING * 2 - CARD_GAP) / 2;
 
 export default function InventoryScreen() {
     const dbContext = useContext(DatabaseContext);
-    const databaseService = dbContext?.databaseService;
-    const isDbReady = dbContext?.isDbReady ?? false;
-
     const { storeConfig } = useAuth();
 
-    const [items, setItems] = useState<GroceryItem[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [search, setSearch] = useState('');
+    const {
+        items,
+        isLoading,
+        isRefreshing,
+        isLoadingMore,
+        hasMore,
+        search,
+        setSearch,
+        error,
+        clearError,
+        refresh,
+        loadMore,
+        incrementStock,
+        decrementStock,
+        createOrder,
+    } = useInventory({
+        databaseService: dbContext?.databaseService,
+        isDbReady: dbContext?.isDbReady ?? false,
+    });
 
-    // Reorder modal state
+    // Reorder modal state stays here — it's a screen-level UI concern.
     const [reorderItem, setReorderItem] = useState<GroceryItem | null>(null);
     const [reorderQty, setReorderQty] = useState('');
 
-    // Debounce timer for change listener to avoid rapid re-queries during sync
-    const changeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const isQueryingRef = useRef(false);
-    const listenerTokenRef = useRef<any>(null);
-
-    const loadItems = useCallback(async () => {
-        if (!databaseService || !isDbReady) return;
-        // Prevent concurrent queries
-        if (isQueryingRef.current) return;
-        isQueryingRef.current = true;
-        try {
-            const data = await databaseService.getInventoryItems();
-            setItems(data);
-        } catch (e) {
-            console.warn('[Inventory] Load error (may be transient during sync):', e);
-        } finally {
-            isQueryingRef.current = false;
-            setIsLoading(false);
-        }
-    }, [databaseService, isDbReady]);
-
-    // Keep a stable ref to loadItems so the listener effect doesn't re-register
-    const loadItemsRef = useRef(loadItems);
-    loadItemsRef.current = loadItems;
-
-    // Initial data load
-    useEffect(() => {
-        if (isDbReady) {
-            loadItems();
-        }
-    }, [isDbReady, loadItems]);
-
-    // Register change listener ONCE, remove on cleanup to avoid orphaned tokens
-    useEffect(() => {
-        if (!isDbReady || !databaseService) return;
-
-        let cancelled = false;
-
-        const register = async () => {
-            const token = await databaseService.addInventoryChangeListener(() => {
-                if (cancelled) return;
-                if (changeTimerRef.current) {
-                    clearTimeout(changeTimerRef.current);
-                }
-                changeTimerRef.current = setTimeout(() => {
-                    loadItemsRef.current();
-                }, 300);
-            });
-            if (!cancelled) {
-                listenerTokenRef.current = token;
-            } else if (token && typeof token.remove === 'function') {
-                // Effect was cleaned up before registration completed
-                await token.remove();
-            }
-        };
-        register();
-
-        return () => {
-            cancelled = true;
-            if (changeTimerRef.current) {
-                clearTimeout(changeTimerRef.current);
-            }
-            // Remove the listener token to prevent orphaned callbacks
-            const token = listenerTokenRef.current;
-            if (token && typeof token.remove === 'function') {
-                token.remove().catch((e: any) =>
-                    console.warn('[Inventory] Error removing listener:', e)
-                );
-            }
-            listenerTokenRef.current = null;
-        };
-    }, [isDbReady, databaseService]);
-
-    const searchItems = useCallback(async (term: string) => {
-        if (!databaseService || !isDbReady) return;
-        setIsLoading(true);
-        try {
-            if (term.length > 0) {
-                const data = await databaseService.searchInventory(term);
-                setItems(data);
-            } else {
-                const data = await databaseService.getInventoryItems();
-                setItems(data);
-            }
-        } catch (e) {
-            console.error('[Inventory] Search error:', e);
-        } finally {
-            setIsLoading(false);
-        }
-    }, [databaseService, isDbReady]);
-
-    const debouncedSearch = useCallback(debounce(searchItems, 400), [searchItems]);
-
-    function onSearch(text: string) {
-        setSearch(text);
-        debouncedSearch(text);
-    }
-
-    async function handleDecrement(item: GroceryItem) {
-        if (!databaseService || item.stockQty <= 0) return;
-        await databaseService.updateStockQuantity(item.id, item.stockQty - 1);
-        await loadItems();
-    }
-
-    async function handleIncrement(item: GroceryItem) {
-        if (!databaseService) return;
-        await databaseService.updateStockQuantity(item.id, item.stockQty + 1);
-        await loadItems();
-    }
-
     async function handleCreateOrder() {
-        if (!reorderItem || !databaseService) return;
+        if (!reorderItem) return;
         const qty = parseInt(reorderQty, 10);
         if (isNaN(qty) || qty <= 0) {
             Alert.alert('Invalid', 'Please enter a valid order quantity');
             return;
         }
-        await databaseService.createOrder(reorderItem, qty);
-        Alert.alert('Order Created', `Reorder for ${reorderItem.name} (qty: ${qty}) submitted.`);
-        setReorderItem(null);
-        setReorderQty('');
+        const ok = await createOrder(reorderItem, qty);
+        if (ok) {
+            Alert.alert('Order Created', `Reorder for ${reorderItem.name} (qty: ${qty}) submitted.`);
+            setReorderItem(null);
+            setReorderQty('');
+        }
+        // On failure the hook surfaces the error via the ErrorBanner; keep the modal open.
     }
 
     const renderItem = ({ item }: { item: GroceryItem }) => (
         <View style={styles.card}>
-            {/* Product Image */}
             <View style={styles.imageContainer}>
                 {item.imageURL ? (
                     <Image source={{ uri: item.imageURL }} style={styles.productImage} resizeMode="cover" />
@@ -176,33 +83,23 @@ export default function InventoryScreen() {
                 )}
             </View>
 
-            {/* Product Info */}
             <Text style={styles.productName} numberOfLines={2}>{item.name || 'Unknown'}</Text>
             <Text style={styles.productPrice}>${(Number(item.price) || 0).toFixed(2)}</Text>
 
-            {/* Inventory Count */}
             <Text style={styles.inventoryLabel}>Inventory Count</Text>
             <Text style={[styles.inventoryCount, { color: getQuantityColor(Number(item.stockQty) || 0) }]}>
                 {Number(item.stockQty) || 0}
             </Text>
 
-            {/* +/- Buttons */}
             <View style={styles.qtyButtons}>
-                <TouchableOpacity
-                    style={styles.qtyBtn}
-                    onPress={() => handleDecrement(item)}
-                >
+                <TouchableOpacity style={styles.qtyBtn} onPress={() => decrementStock(item)}>
                     <Ionicons name="remove" size={20} color="#007AFF" />
                 </TouchableOpacity>
-                <TouchableOpacity
-                    style={styles.qtyBtn}
-                    onPress={() => handleIncrement(item)}
-                >
+                <TouchableOpacity style={styles.qtyBtn} onPress={() => incrementStock(item)}>
                     <Ionicons name="add" size={20} color="#007AFF" />
                 </TouchableOpacity>
             </View>
 
-            {/* Reorder Button */}
             <TouchableOpacity
                 style={styles.reorderBtn}
                 onPress={() => {
@@ -217,13 +114,39 @@ export default function InventoryScreen() {
         </View>
     );
 
-    // Welcome header with store name
     const storeName = storeConfig?.displayName || 'Store';
     const role = storeConfig?.role || 'Manager';
 
+    const initError = dbContext?.initError ?? null;
+    const errorBannerProps = (() => {
+        if (initError) {
+            return {
+                title: 'Database failed to start',
+                message: initError.message,
+                onRetry: dbContext?.retryInit,
+            };
+        }
+        if (error) {
+            const titleByOp = {
+                load: 'Could not load inventory',
+                search: 'Search failed',
+                updateStock: 'Could not update stock',
+                createOrder: 'Could not create order',
+            } as const;
+            return {
+                title: titleByOp[error.op],
+                message: error.error.message,
+                onRetry: error.op === 'load' || error.op === 'search'
+                    ? () => { clearError(); refresh(); }
+                    : undefined,
+                onDismiss: clearError,
+            };
+        }
+        return null;
+    })();
+
     return (
         <SafeAreaView style={styles.container}>
-            {/* Welcome Header */}
             <View style={styles.welcomeHeader}>
                 <View style={styles.welcomeRow}>
                     <Text style={styles.welcomeText} numberOfLines={1}>
@@ -236,9 +159,11 @@ export default function InventoryScreen() {
                 <Text style={styles.screenTitle}>Grocery Inventory</Text>
             </View>
 
+            {errorBannerProps && <ErrorBanner {...errorBannerProps} />}
+
             <ThemedSearchBar
                 placeholder="Search grocery..."
-                onChangeText={onSearch}
+                onChangeText={setSearch}
                 value={search}
             />
 
@@ -249,7 +174,11 @@ export default function InventoryScreen() {
             ) : items.length === 0 ? (
                 <View style={styles.emptyContainer}>
                     <Ionicons name="cube-outline" size={64} color="#C7C7CC" />
-                    <Text style={styles.emptyText}>No inventory items found</Text>
+                    <Text style={styles.emptyText}>
+                        {search.length > 0
+                            ? `No results for "${search}"`
+                            : 'No inventory items found'}
+                    </Text>
                 </View>
             ) : (
                 <FlatList
@@ -259,10 +188,25 @@ export default function InventoryScreen() {
                     numColumns={2}
                     contentContainerStyle={styles.grid}
                     columnWrapperStyle={styles.gridRow}
+                    refreshControl={
+                        <RefreshControl
+                            refreshing={isRefreshing}
+                            onRefresh={refresh}
+                            tintColor="#FC9C0C"
+                        />
+                    }
+                    onEndReached={hasMore ? loadMore : undefined}
+                    onEndReachedThreshold={0.4}
+                    ListFooterComponent={
+                        isLoadingMore ? (
+                            <View style={styles.footer}>
+                                <ActivityIndicator size="small" color="#FC9C0C" />
+                            </View>
+                        ) : null
+                    }
                 />
             )}
 
-            {/* Reorder Modal */}
             <Modal visible={reorderItem !== null} transparent animationType="fade">
                 <View style={styles.modalOverlay}>
                     <View style={styles.modalContent}>
@@ -319,9 +263,10 @@ const styles = StyleSheet.create({
     screenTitle: { fontSize: 28, fontWeight: 'bold', color: '#1C1C1E', marginTop: 2 },
     spinnerContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
     emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 12 },
-    emptyText: { fontSize: 16, color: '#8E8E93' },
+    emptyText: { fontSize: 16, color: '#8E8E93', paddingHorizontal: 24, textAlign: 'center' },
     grid: { paddingHorizontal: CARD_PADDING, paddingBottom: 20, paddingTop: 8 },
     gridRow: { justifyContent: 'space-between', marginBottom: CARD_GAP },
+    footer: { paddingVertical: 16, alignItems: 'center' },
     card: {
         width: CARD_WIDTH,
         backgroundColor: '#fff',
@@ -404,7 +349,6 @@ const styles = StyleSheet.create({
         fontWeight: '600',
         color: '#fff',
     },
-    // Modal
     modalOverlay: {
         flex: 1,
         backgroundColor: 'rgba(0,0,0,0.4)',

--- a/react-native/app/(tabs)/index.tsx
+++ b/react-native/app/(tabs)/index.tsx
@@ -62,13 +62,20 @@ export default function InventoryScreen() {
             Alert.alert('Invalid', 'Please enter a valid order quantity');
             return;
         }
-        const ok = await createOrder(reorderItem, qty);
-        if (ok) {
+        const result = await createOrder(reorderItem, qty);
+        if (result.ok) {
             Alert.alert('Order Created', `Reorder for ${reorderItem.name} (qty: ${qty}) submitted.`);
             setReorderItem(null);
             setReorderQty('');
+            return;
         }
-        // On failure the hook surfaces the error via the ErrorBanner; keep the modal open.
+        // The reorder Modal sits on top of the screen, so the ErrorBanner
+        // would be hidden behind it. Surface the failure directly via an
+        // Alert — the native system dialog renders above the Modal — and
+        // clear the hook's error so the banner doesn't flash on screen
+        // the moment the modal eventually closes.
+        clearError();
+        Alert.alert('Order Failed', result.error.message);
     }
 
     const renderItem = ({ item }: { item: GroceryItem }) => (

--- a/react-native/app/(tabs)/orders.tsx
+++ b/react-native/app/(tabs)/orders.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import {
     ActivityIndicator,
     FlatList,
@@ -7,101 +7,61 @@ import {
     View,
     Text,
     TouchableOpacity,
+    RefreshControl,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import DatabaseContext from '@/providers/DatabaseContext';
+import { ErrorBanner } from '@/components/feedback/ErrorBanner';
 import { Order, formatOrderDate, getOrderStatusColor } from '@/models/Order';
+import { useOrders } from '@/hooks/useOrders';
 
 const FILTERS = ['All', 'In Review', 'Approved'] as const;
 type FilterType = typeof FILTERS[number];
 
 export default function OrdersScreen() {
     const dbContext = useContext(DatabaseContext);
-    const databaseService = dbContext?.databaseService;
-    const isDbReady = dbContext?.isDbReady ?? false;
 
-    const [orders, setOrders] = useState<Order[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
+    const {
+        orders,
+        isLoading,
+        isRefreshing,
+        isLoadingMore,
+        hasMore,
+        error,
+        clearError,
+        refresh,
+        loadMore,
+    } = useOrders({
+        databaseService: dbContext?.databaseService,
+        isDbReady: dbContext?.isDbReady ?? false,
+    });
+
     const [activeFilter, setActiveFilter] = useState<FilterType>('All');
-
-    const changeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const isQueryingRef = useRef(false);
-    const listenerTokenRef = useRef<any>(null);
-
-    const loadOrders = useCallback(async () => {
-        if (!databaseService || !isDbReady) return;
-        if (isQueryingRef.current) return;
-        isQueryingRef.current = true;
-        try {
-            const data = await databaseService.getOrders();
-            setOrders(data);
-        } catch (e) {
-            console.warn('[Orders] Load error (may be transient during sync):', e);
-        } finally {
-            isQueryingRef.current = false;
-            setIsLoading(false);
-        }
-    }, [databaseService, isDbReady]);
-
-    // Keep a stable ref to loadOrders so the listener effect doesn't re-register
-    const loadOrdersRef = useRef(loadOrders);
-    loadOrdersRef.current = loadOrders;
-
-    // Initial data load
-    useEffect(() => {
-        if (isDbReady) {
-            loadOrders();
-        }
-    }, [isDbReady, loadOrders]);
-
-    // Register change listener ONCE, remove on cleanup to avoid orphaned tokens
-    useEffect(() => {
-        if (!isDbReady || !databaseService) return;
-
-        let cancelled = false;
-
-        const register = async () => {
-            const token = await databaseService.addOrdersChangeListener(() => {
-                if (cancelled) return;
-                if (changeTimerRef.current) {
-                    clearTimeout(changeTimerRef.current);
-                }
-                changeTimerRef.current = setTimeout(() => {
-                    loadOrdersRef.current();
-                }, 300);
-            });
-            if (!cancelled) {
-                listenerTokenRef.current = token;
-            } else if (token && typeof token.remove === 'function') {
-                await token.remove();
-            }
-        };
-        register();
-
-        return () => {
-            cancelled = true;
-            if (changeTimerRef.current) {
-                clearTimeout(changeTimerRef.current);
-            }
-            const token = listenerTokenRef.current;
-            if (token && typeof token.remove === 'function') {
-                token.remove().catch((e: any) =>
-                    console.warn('[Orders] Error removing listener:', e)
-                );
-            }
-            listenerTokenRef.current = null;
-        };
-    }, [isDbReady, databaseService]);
 
     const filteredOrders = useMemo(() => {
         if (activeFilter === 'All') return orders;
         return orders.filter(o => o.orderStatus === activeFilter);
     }, [orders, activeFilter]);
 
-    const handleRefresh = () => {
-        setIsLoading(true);
-        loadOrders();
-    };
+    const initError = dbContext?.initError ?? null;
+    const errorBannerProps = (() => {
+        if (initError) {
+            return {
+                title: 'Database failed to start',
+                message: initError.message,
+                onRetry: dbContext?.retryInit,
+            };
+        }
+        if (error) {
+            return {
+                title: 'Could not load orders',
+                message: error.error.message,
+                onRetry: () => { clearError(); refresh(); },
+                onDismiss: clearError,
+            };
+        }
+        return null;
+    })();
 
     const renderOrder = ({ item }: { item: Order }) => (
         <View style={styles.card}>
@@ -127,16 +87,16 @@ export default function OrdersScreen() {
 
     return (
         <SafeAreaView style={styles.container}>
-            {/* Header */}
             <View style={styles.headerBar}>
-                <TouchableOpacity onPress={handleRefresh} style={styles.headerBtn}>
+                <TouchableOpacity onPress={refresh} style={styles.headerBtn}>
                     <Ionicons name="refresh" size={20} color="#007AFF" />
                 </TouchableOpacity>
                 <Text style={styles.headerTitle}>Orders</Text>
                 <View style={styles.headerBtn} />
             </View>
 
-            {/* Segmented Control */}
+            {errorBannerProps && <ErrorBanner {...errorBannerProps} />}
+
             <View style={styles.segmentContainer}>
                 {FILTERS.map(filter => (
                     <TouchableOpacity
@@ -179,6 +139,22 @@ export default function OrdersScreen() {
                     renderItem={renderOrder}
                     keyExtractor={(item) => item.id}
                     contentContainerStyle={styles.list}
+                    refreshControl={
+                        <RefreshControl
+                            refreshing={isRefreshing}
+                            onRefresh={refresh}
+                            tintColor="#FC9C0C"
+                        />
+                    }
+                    onEndReached={hasMore && activeFilter === 'All' ? loadMore : undefined}
+                    onEndReachedThreshold={0.4}
+                    ListFooterComponent={
+                        isLoadingMore ? (
+                            <View style={styles.footer}>
+                                <ActivityIndicator size="small" color="#FC9C0C" />
+                            </View>
+                        ) : null
+                    }
                 />
             )}
         </SafeAreaView>
@@ -234,6 +210,7 @@ const styles = StyleSheet.create({
     emptyTitle: { fontSize: 18, fontWeight: '600', color: '#8E8E93' },
     emptySubtitle: { fontSize: 14, color: '#AEAEB2', textAlign: 'center', paddingHorizontal: 40 },
     list: { paddingHorizontal: 16, paddingBottom: 20 },
+    footer: { paddingVertical: 16, alignItems: 'center' },
     card: {
         backgroundColor: '#fff',
         borderRadius: 12,

--- a/react-native/app/(tabs)/orders.tsx
+++ b/react-native/app/(tabs)/orders.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useState } from 'react';
 import {
     ActivityIndicator,
     FlatList,
@@ -21,6 +21,8 @@ type FilterType = typeof FILTERS[number];
 export default function OrdersScreen() {
     const dbContext = useContext(DatabaseContext);
 
+    const [activeFilter, setActiveFilter] = useState<FilterType>('All');
+
     const {
         orders,
         isLoading,
@@ -34,14 +36,10 @@ export default function OrdersScreen() {
     } = useOrders({
         databaseService: dbContext?.databaseService,
         isDbReady: dbContext?.isDbReady ?? false,
+        // The filter is applied at the database level so that pagination
+        // works correctly regardless of which tab is active.
+        status: activeFilter === 'All' ? undefined : activeFilter,
     });
-
-    const [activeFilter, setActiveFilter] = useState<FilterType>('All');
-
-    const filteredOrders = useMemo(() => {
-        if (activeFilter === 'All') return orders;
-        return orders.filter(o => o.orderStatus === activeFilter);
-    }, [orders, activeFilter]);
 
     const initError = dbContext?.initError ?? null;
     const errorBannerProps = (() => {
@@ -123,7 +121,7 @@ export default function OrdersScreen() {
                 <View style={styles.spinnerContainer}>
                     <ActivityIndicator size="large" color="#FC9C0C" />
                 </View>
-            ) : filteredOrders.length === 0 ? (
+            ) : orders.length === 0 ? (
                 <View style={styles.emptyContainer}>
                     <Ionicons name="receipt-outline" size={64} color="#C7C7CC" />
                     <Text style={styles.emptyTitle}>No Orders</Text>
@@ -135,7 +133,7 @@ export default function OrdersScreen() {
                 </View>
             ) : (
                 <FlatList
-                    data={filteredOrders}
+                    data={orders}
                     renderItem={renderOrder}
                     keyExtractor={(item) => item.id}
                     contentContainerStyle={styles.list}
@@ -146,7 +144,7 @@ export default function OrdersScreen() {
                             tintColor="#FC9C0C"
                         />
                     }
-                    onEndReached={hasMore && activeFilter === 'All' ? loadMore : undefined}
+                    onEndReached={hasMore ? loadMore : undefined}
                     onEndReachedThreshold={0.4}
                     ListFooterComponent={
                         isLoadingMore ? (

--- a/react-native/app/(tabs)/profile.tsx
+++ b/react-native/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import {
     ActivityIndicator,
     SafeAreaView,
@@ -6,39 +6,48 @@ import {
     StyleSheet,
     View,
     Text,
+    RefreshControl,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import DatabaseContext from '@/providers/DatabaseContext';
 import { useAuth } from '@/providers/AuthContext';
-import { StoreProfile } from '@/models/StoreProfile';
+import { ErrorBanner } from '@/components/feedback/ErrorBanner';
+import { useStoreProfile } from '@/hooks/useStoreProfile';
 
 export default function ProfileScreen() {
     const dbContext = useContext(DatabaseContext);
-    const databaseService = dbContext?.databaseService;
-    const isDbReady = dbContext?.isDbReady ?? false;
-
     const { storeConfig } = useAuth();
-    const [profile, setProfile] = useState<StoreProfile | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
 
-    useEffect(() => {
-        if (!databaseService || !isDbReady) return;
-        const load = async () => {
-            try {
-                const data = await databaseService.getStoreProfile();
-                setProfile(data);
-            } catch (e) {
-                console.error('[Profile] Load error:', e);
-            } finally {
-                setIsLoading(false);
-            }
-        };
-        load();
-    }, [databaseService, isDbReady]);
+    const { profile, isLoading, isRefreshing, error, clearError, refresh } =
+        useStoreProfile({
+            databaseService: dbContext?.databaseService,
+            isDbReady: dbContext?.isDbReady ?? false,
+        });
 
-    if (isLoading) {
+    const initError = dbContext?.initError ?? null;
+    const errorBannerProps = (() => {
+        if (initError) {
+            return {
+                title: 'Database failed to start',
+                message: initError.message,
+                onRetry: dbContext?.retryInit,
+            };
+        }
+        if (error) {
+            return {
+                title: 'Could not load store profile',
+                message: error.error.message,
+                onRetry: () => { clearError(); refresh(); },
+                onDismiss: clearError,
+            };
+        }
+        return null;
+    })();
+
+    if (isLoading && !profile) {
         return (
             <SafeAreaView style={styles.container}>
+                {errorBannerProps && <ErrorBanner {...errorBannerProps} />}
                 <View style={styles.spinnerContainer}>
                     <ActivityIndicator size="large" color="#FC9C0C" />
                 </View>
@@ -48,8 +57,13 @@ export default function ProfileScreen() {
 
     return (
         <SafeAreaView style={styles.container}>
-            <ScrollView contentContainerStyle={styles.scrollContent}>
-                {/* Store Header */}
+            {errorBannerProps && <ErrorBanner {...errorBannerProps} />}
+            <ScrollView
+                contentContainerStyle={styles.scrollContent}
+                refreshControl={
+                    <RefreshControl refreshing={isRefreshing} onRefresh={refresh} tintColor="#FC9C0C" />
+                }
+            >
                 <View style={styles.headerCard}>
                     <View style={styles.avatarContainer}>
                         <Ionicons name="storefront" size={40} color="#FC9C0C" />
@@ -63,7 +77,6 @@ export default function ProfileScreen() {
                     </View>
                 </View>
 
-                {/* Contact Info */}
                 {profile?.contact && (
                     <>
                         <Text style={styles.sectionHeader}>CONTACT</Text>
@@ -97,7 +110,6 @@ export default function ProfileScreen() {
                     </>
                 )}
 
-                {/* Location */}
                 {profile?.location && (
                     <>
                         <Text style={styles.sectionHeader}>LOCATION</Text>
@@ -121,7 +133,6 @@ export default function ProfileScreen() {
                     </>
                 )}
 
-                {/* Opening Hours */}
                 {profile?.openingHours && (
                     <>
                         <Text style={styles.sectionHeader}>HOURS</Text>
@@ -131,7 +142,6 @@ export default function ProfileScreen() {
                     </>
                 )}
 
-                {/* Account */}
                 <Text style={styles.sectionHeader}>ACCOUNT</Text>
                 <View style={styles.sectionCard}>
                     <InfoRow icon="person-circle-outline" label="Username" value={storeConfig?.username || '—'} />

--- a/react-native/app/(tabs)/settings.tsx
+++ b/react-native/app/(tabs)/settings.tsx
@@ -13,11 +13,13 @@ import { Ionicons } from '@expo/vector-icons';
 import DatabaseContext from '@/providers/DatabaseContext';
 import { useAuth } from '@/providers/AuthContext';
 import { APP_CONFIG } from '@/models/AppConfig';
+import { ErrorBanner } from '@/components/feedback/ErrorBanner';
 
 export default function SettingsScreen() {
     const dbContext = useContext(DatabaseContext);
     const syncStatus = dbContext?.syncStatus ?? 'stopped';
     const isDbReady = dbContext?.isDbReady ?? false;
+    const initError = dbContext?.initError ?? null;
     const { storeConfig, logout } = useAuth();
 
     const syncColor = syncStatus === 'idle' ? '#34C759'
@@ -37,6 +39,13 @@ export default function SettingsScreen() {
 
     return (
         <SafeAreaView style={styles.container}>
+            {initError && (
+                <ErrorBanner
+                    title="Database failed to start"
+                    message={initError.message}
+                    onRetry={dbContext?.retryInit}
+                />
+            )}
             <ScrollView contentContainerStyle={styles.scrollContent}>
                 {/* User Info Header */}
                 <View style={styles.userCard}>

--- a/react-native/components/feedback/ErrorBanner.tsx
+++ b/react-native/components/feedback/ErrorBanner.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+type Props = {
+    title?: string;
+    message: string;
+    /** When provided, a "Retry" button is rendered. */
+    onRetry?: () => void;
+    /** When provided, a close (X) button is rendered. */
+    onDismiss?: () => void;
+    /**
+     * 'error' (default) → red, 'warning' → orange. Reserved for future use;
+     * for now both render with the same red palette so the visual is loud.
+     */
+    severity?: 'error' | 'warning';
+};
+
+/**
+ * Top-of-screen banner used by all data screens to surface failures in
+ * Couchbase Lite initialization, App Services auth, sync, queries, and
+ * mutations. Keeps the UI a single source of truth for error styling.
+ */
+export function ErrorBanner({
+    title = 'Something went wrong',
+    message,
+    onRetry,
+    onDismiss,
+    severity = 'error',
+}: Props) {
+    const palette = severity === 'warning'
+        ? { bg: '#FFF4E5', border: '#FFB74D', icon: '#E65100', text: '#5D4037' }
+        : { bg: '#FFEBEE', border: '#EF5350', icon: '#B71C1C', text: '#5D1A1A' };
+
+    return (
+        <View
+            style={[
+                styles.container,
+                { backgroundColor: palette.bg, borderLeftColor: palette.border },
+            ]}
+            accessibilityRole="alert"
+            accessibilityLabel={`${title}. ${message}`}
+        >
+            <Ionicons
+                name={severity === 'warning' ? 'warning-outline' : 'alert-circle-outline'}
+                size={20}
+                color={palette.icon}
+                style={styles.icon}
+            />
+            <View style={styles.body}>
+                <Text style={[styles.title, { color: palette.text }]}>{title}</Text>
+                <Text style={[styles.message, { color: palette.text }]} numberOfLines={3}>
+                    {message}
+                </Text>
+                {onRetry && (
+                    <TouchableOpacity
+                        style={[styles.retryBtn, { borderColor: palette.border }]}
+                        onPress={onRetry}
+                        accessibilityRole="button"
+                    >
+                        <Ionicons name="refresh" size={14} color={palette.icon} />
+                        <Text style={[styles.retryText, { color: palette.icon }]}>Retry</Text>
+                    </TouchableOpacity>
+                )}
+            </View>
+            {onDismiss && (
+                <TouchableOpacity
+                    onPress={onDismiss}
+                    accessibilityRole="button"
+                    accessibilityLabel="Dismiss error"
+                    hitSlop={8}
+                    style={styles.dismiss}
+                >
+                    <Ionicons name="close" size={18} color={palette.icon} />
+                </TouchableOpacity>
+            )}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        gap: 10,
+        marginHorizontal: 16,
+        marginTop: 8,
+        marginBottom: 4,
+        paddingVertical: 12,
+        paddingHorizontal: 14,
+        borderRadius: 10,
+        borderLeftWidth: 4,
+    },
+    icon: { marginTop: 1 },
+    body: { flex: 1 },
+    title: { fontSize: 14, fontWeight: '700', marginBottom: 2 },
+    message: { fontSize: 13, lineHeight: 18 },
+    retryBtn: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 4,
+        marginTop: 8,
+        alignSelf: 'flex-start',
+        paddingHorizontal: 10,
+        paddingVertical: 5,
+        borderRadius: 6,
+        borderWidth: 1,
+        backgroundColor: '#FFFFFF',
+    },
+    retryText: { fontSize: 12, fontWeight: '600' },
+    dismiss: { paddingTop: 1, paddingLeft: 4 },
+});

--- a/react-native/hooks/useAppStateRefresh.ts
+++ b/react-native/hooks/useAppStateRefresh.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+type Options = {
+    /** Skip the subscription entirely when false. */
+    enabled?: boolean;
+    /**
+     * Minimum time (ms) the app must have been backgrounded before we treat
+     * a foreground transition as "needs refresh". Keeps quick app switches
+     * from triggering a flood of queries. Default 2s.
+     */
+    minBackgroundedMs?: number;
+};
+
+/**
+ * Calls {@code onForeground} whenever the app transitions back to the
+ * 'active' state from 'background' or 'inactive'. The screen using this hook
+ * decides what "refresh" means — typically calling its data-loading callback.
+ *
+ * Only one listener is registered per component instance, and it is cleaned
+ * up automatically. The `onForeground` reference does not need to be stable
+ * across renders — we proxy it through a ref so every render's callback is
+ * picked up without re-subscribing.
+ */
+export function useAppStateRefresh(
+    onForeground: () => void,
+    options: Options = {},
+): void {
+    const { enabled = true, minBackgroundedMs = 2000 } = options;
+    const callbackRef = useRef(onForeground);
+    callbackRef.current = onForeground;
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        let lastState: AppStateStatus = AppState.currentState;
+        let backgroundedAt: number | null = null;
+
+        const handleChange = (next: AppStateStatus) => {
+            const prev = lastState;
+            lastState = next;
+
+            if (next !== 'active' && (prev === 'active' || prev === 'unknown')) {
+                backgroundedAt = Date.now();
+                return;
+            }
+
+            if (next === 'active' && prev !== 'active') {
+                const elapsed = backgroundedAt ? Date.now() - backgroundedAt : Infinity;
+                backgroundedAt = null;
+                if (elapsed >= minBackgroundedMs) {
+                    callbackRef.current();
+                }
+            }
+        };
+
+        const sub = AppState.addEventListener('change', handleChange);
+        return () => {
+            sub.remove();
+        };
+    }, [enabled, minBackgroundedMs]);
+}

--- a/react-native/hooks/useCollectionListener.ts
+++ b/react-native/hooks/useCollectionListener.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Couchbase Lite returns a listener token shaped like `{ remove: () => Promise<void> }`.
+ * We intentionally keep this loose — `cbl-reactnative` doesn't export the token type
+ * and the only thing we ever do with it is call `.remove()`.
+ */
+type ListenerToken = { remove: () => Promise<void> } | undefined | null;
+
+type RegisterFn = (cb: () => void) => Promise<ListenerToken>;
+
+type UseCollectionListenerOptions = {
+    /** Skip registration entirely when false. */
+    enabled?: boolean;
+    /**
+     * Debounce delay (ms) before invoking `onChange`. Helps avoid rapid
+     * re-queries while sync is streaming a burst of updates.
+     */
+    debounceMs?: number;
+    /**
+     * Optional tag used in console.warn messages so multiple listeners stay
+     * distinguishable in logs.
+     */
+    label?: string;
+};
+
+/**
+ * Subscribes to a Couchbase Lite collection change listener for as long as
+ * the host component is mounted.
+ *
+ * Handles three subtle correctness issues we hit when each screen wrote its
+ * own listener wiring:
+ *  1. The component can unmount before the async `register` Promise resolves.
+ *     If it does, we still need to remove the (now stale) token.
+ *  2. The change event can fire dozens of times per second during initial
+ *     replication; debounce keeps the UI snappy.
+ *  3. Listener tokens MUST be removed before `database.close()` runs, otherwise
+ *     `cbl-reactnative` logs "orphaned callback" warnings on logout.
+ *
+ * The hook accepts a `register` callback rather than the collection itself so
+ * each screen can stay decoupled from the {@link DatabaseService} internals.
+ */
+export function useCollectionListener(
+    register: RegisterFn | undefined | null,
+    onChange: () => void,
+    deps: ReadonlyArray<unknown>,
+    options: UseCollectionListenerOptions = {},
+): void {
+    const { enabled = true, debounceMs = 300, label = 'collection' } = options;
+
+    // Stash the latest `onChange` in a ref so we don't re-subscribe every
+    // time the parent component re-renders with a new closure.
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+
+    useEffect(() => {
+        if (!enabled || !register) return;
+
+        let cancelled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        let token: ListenerToken = null;
+
+        const fire = () => {
+            if (cancelled) return;
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(() => {
+                if (cancelled) return;
+                onChangeRef.current();
+            }, Math.max(0, debounceMs));
+        };
+
+        const subscribe = async () => {
+            try {
+                const t = await register(fire);
+                if (cancelled) {
+                    // Component unmounted before subscribe finished; clean up immediately.
+                    if (t && typeof t.remove === 'function') {
+                        await t.remove().catch((e: unknown) =>
+                            console.warn(`[useCollectionListener:${label}] late remove error`, e),
+                        );
+                    }
+                    return;
+                }
+                token = t;
+            } catch (e) {
+                console.warn(`[useCollectionListener:${label}] subscribe failed`, e);
+            }
+        };
+
+        subscribe();
+
+        return () => {
+            cancelled = true;
+            if (timer) clearTimeout(timer);
+            if (token && typeof token.remove === 'function') {
+                token.remove().catch((e: unknown) =>
+                    console.warn(`[useCollectionListener:${label}] remove error`, e),
+                );
+            }
+            token = null;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled, register, debounceMs, label, ...deps]);
+}

--- a/react-native/hooks/useCollectionListener.ts
+++ b/react-native/hooks/useCollectionListener.ts
@@ -39,11 +39,15 @@ type UseCollectionListenerOptions = {
  *
  * The hook accepts a `register` callback rather than the collection itself so
  * each screen can stay decoupled from the {@link DatabaseService} internals.
+ *
+ * `onChange` is read through a ref, so callers don't need to memoise it; the
+ * hook only re-subscribes when `register` (the function that creates the
+ * listener) actually changes. If a caller needs the subscription to restart
+ * for some other reason, they can vary the `register` reference itself.
  */
 export function useCollectionListener(
     register: RegisterFn | undefined | null,
     onChange: () => void,
-    deps: ReadonlyArray<unknown>,
     options: UseCollectionListenerOptions = {},
 ): void {
     const { enabled = true, debounceMs = 300, label = 'collection' } = options;
@@ -99,6 +103,5 @@ export function useCollectionListener(
             }
             token = null;
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [enabled, register, debounceMs, label, ...deps]);
+    }, [enabled, register, debounceMs, label]);
 }

--- a/react-native/hooks/useInventory.ts
+++ b/react-native/hooks/useInventory.ts
@@ -58,6 +58,12 @@ type Args = {
  *   - `refresh()` re-fetches the first page and resets `hasMore`.
  *   - `loadMore()` appends the next page using LIMIT/OFFSET.
  *   - When the user types in the search box we always reset to page 0.
+ *
+ * Concurrency: `reload()` uses a "latest request" pattern — every call gets
+ * a unique request id; only the latest request's results are applied to
+ * state, so a slow query for the previous search term cannot clobber the UI
+ * after the user has typed something newer. `loadMore()` is serialized via
+ * its own flag so we never append the same page twice.
  */
 export function useInventory({
     databaseService,
@@ -74,7 +80,14 @@ export function useInventory({
 
     const offsetRef = useRef(0);
     const searchRef = useRef('');
-    const isQueryingRef = useRef(false);
+    /**
+     * Monotonic counter used to identify the most recent reload() call.
+     * Each call increments this and snapshots the value; only the call whose
+     * snapshot still matches when its query resolves is allowed to apply
+     * its results. Older in-flight queries silently drop their results.
+     */
+    const reloadIdRef = useRef(0);
+    const isLoadingMoreRef = useRef(false);
 
     const ready = isDbReady && !!databaseService;
 
@@ -91,47 +104,60 @@ export function useInventory({
     const reload = useCallback(
         async (term: string, opts: { manual?: boolean } = {}) => {
             if (!ready) return;
-            if (isQueryingRef.current) return;
-            isQueryingRef.current = true;
 
+            const requestId = ++reloadIdRef.current;
             if (opts.manual) setIsRefreshing(true);
             try {
                 const data = await fetchPage(0, term);
+                // If a newer reload has been issued in the meantime, drop these
+                // stale results — the newer call will paint authoritative state.
+                if (reloadIdRef.current !== requestId) return;
                 setItems(data);
                 offsetRef.current = data.length;
                 setHasMore(data.length >= pageSize);
                 setError(null);
             } catch (e) {
+                if (reloadIdRef.current !== requestId) return;
                 console.error('[useInventory] reload error', e);
                 setError({ op: term ? 'search' : 'load', error: toError(e) });
             } finally {
-                isQueryingRef.current = false;
-                setIsLoading(false);
-                if (opts.manual) setIsRefreshing(false);
+                if (reloadIdRef.current === requestId) {
+                    setIsLoading(false);
+                    if (opts.manual) setIsRefreshing(false);
+                }
             }
         },
         [ready, fetchPage, pageSize],
     );
 
     const loadMore = useCallback(async () => {
-        if (!ready || !hasMore || isLoadingMore || isQueryingRef.current) return;
-        isQueryingRef.current = true;
+        if (!ready || !hasMore || isLoadingMoreRef.current) return;
+        // Capture the request id at the moment loadMore was issued. If a
+        // reload() runs between now and when our query resolves, the page
+        // we fetched is for an outdated search/filter and must be discarded.
+        const issuedAtId = reloadIdRef.current;
+        const issuedAtOffset = offsetRef.current;
+        const issuedAtTerm = searchRef.current;
+
+        isLoadingMoreRef.current = true;
         setIsLoadingMore(true);
         try {
-            const next = await fetchPage(offsetRef.current, searchRef.current);
+            const next = await fetchPage(issuedAtOffset, issuedAtTerm);
+            if (reloadIdRef.current !== issuedAtId) return; // superseded
             if (next.length > 0) {
                 setItems(prev => prev.concat(next));
-                offsetRef.current += next.length;
+                offsetRef.current = issuedAtOffset + next.length;
             }
             setHasMore(next.length >= pageSize);
         } catch (e) {
+            if (reloadIdRef.current !== issuedAtId) return;
             console.error('[useInventory] loadMore error', e);
             setError({ op: 'load', error: toError(e) });
         } finally {
-            isQueryingRef.current = false;
+            isLoadingMoreRef.current = false;
             setIsLoadingMore(false);
         }
-    }, [ready, hasMore, isLoadingMore, fetchPage, pageSize]);
+    }, [ready, hasMore, fetchPage, pageSize]);
 
     // Initial load + reset whenever the database becomes ready.
     useEffect(() => {
@@ -181,14 +207,23 @@ export function useInventory({
         await reload(searchRef.current, { manual: true });
     }, [reload]);
 
+    /**
+     * Compute next quantity from the *latest* state inside the functional
+     * setItems updater. This avoids race conditions when the user taps the
+     * +/- button rapidly and the parent's `item` snapshot is stale.
+     */
     const incrementStock = useCallback(async (item: GroceryItem) => {
         if (!databaseService) return;
+        let nextQty: number | null = null;
+        setItems(prev => {
+            const current = prev.find(i => i.id === item.id);
+            const baseline = current?.stockQty ?? item.stockQty;
+            nextQty = baseline + 1;
+            return prev.map(i => (i.id === item.id ? { ...i, stockQty: nextQty as number } : i));
+        });
+        if (nextQty === null) return;
         try {
-            await databaseService.updateStockQuantity(item.id, item.stockQty + 1);
-            // Optimistic update; sync listener will reconcile shortly.
-            setItems(prev =>
-                prev.map(i => (i.id === item.id ? { ...i, stockQty: i.stockQty + 1 } : i)),
-            );
+            await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
             console.error('[useInventory] increment error', e);
             setError({ op: 'updateStock', error: toError(e) });
@@ -196,12 +231,18 @@ export function useInventory({
     }, [databaseService]);
 
     const decrementStock = useCallback(async (item: GroceryItem) => {
-        if (!databaseService || item.stockQty <= 0) return;
+        if (!databaseService) return;
+        let nextQty: number | null = null;
+        setItems(prev => {
+            const current = prev.find(i => i.id === item.id);
+            const baseline = current?.stockQty ?? item.stockQty;
+            if (baseline <= 0) return prev;
+            nextQty = Math.max(0, baseline - 1);
+            return prev.map(i => (i.id === item.id ? { ...i, stockQty: nextQty as number } : i));
+        });
+        if (nextQty === null) return;
         try {
-            await databaseService.updateStockQuantity(item.id, item.stockQty - 1);
-            setItems(prev =>
-                prev.map(i => (i.id === item.id ? { ...i, stockQty: i.stockQty - 1 } : i)),
-            );
+            await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
             console.error('[useInventory] decrement error', e);
             setError({ op: 'updateStock', error: toError(e) });

--- a/react-native/hooks/useInventory.ts
+++ b/react-native/hooks/useInventory.ts
@@ -38,7 +38,15 @@ export type UseInventoryResult = {
     loadMore: () => Promise<void>;
     incrementStock: (item: GroceryItem) => Promise<void>;
     decrementStock: (item: GroceryItem) => Promise<void>;
-    createOrder: (item: GroceryItem, qty: number) => Promise<boolean>;
+    /**
+     * Resolves to `{ ok: true }` on success or `{ ok: false, error }` so the
+     * caller can surface the failure inline (e.g. inside a Modal where the
+     * top-level ErrorBanner would be hidden behind the modal overlay).
+     */
+    createOrder: (
+        item: GroceryItem,
+        qty: number,
+    ) => Promise<{ ok: true } | { ok: false; error: Error }>;
 };
 
 type Args = {
@@ -187,11 +195,16 @@ export function useInventory({
         }
     }, [ready, hasMore, fetchPage, pageSize, updateItems]);
 
-    // Initial load + reset whenever the database becomes ready.
+    // Initial load + reset whenever the database becomes ready. Use the
+    // current searchRef value rather than an empty string so a search
+    // term left in `setSearch` state (e.g. across a brief DB-not-ready
+    // window or a store switch) stays in sync with the rendered list —
+    // otherwise the search box would show a query while the list shows
+    // every item.
     useEffect(() => {
         if (ready) {
             setIsLoading(true);
-            reload('');
+            reload(searchRef.current);
         } else {
             replaceItems([]);
             offsetRef.current = 0;
@@ -301,15 +314,21 @@ export function useInventory({
         }
     }, [databaseService, updateItems]);
 
-    const createOrder = useCallback(async (item: GroceryItem, qty: number) => {
-        if (!databaseService) return false;
+    const createOrder = useCallback(async (
+        item: GroceryItem,
+        qty: number,
+    ): Promise<{ ok: true } | { ok: false; error: Error }> => {
+        if (!databaseService) {
+            return { ok: false, error: new Error('Database not ready') };
+        }
         try {
             await databaseService.createOrder(item, qty);
-            return true;
+            return { ok: true };
         } catch (e) {
             console.error('[useInventory] createOrder error', e);
-            setError({ op: 'createOrder', error: toError(e) });
-            return false;
+            const error = toError(e);
+            setError({ op: 'createOrder', error });
+            return { ok: false, error };
         }
     }, [databaseService]);
 

--- a/react-native/hooks/useInventory.ts
+++ b/react-native/hooks/useInventory.ts
@@ -211,6 +211,11 @@ export function useInventory({
      * Compute next quantity from the *latest* state inside the functional
      * setItems updater. This avoids race conditions when the user taps the
      * +/- button rapidly and the parent's `item` snapshot is stale.
+     *
+     * On DB failure we roll back the optimistic delta (not to a captured
+     * absolute) using another functional update — this stays correct even
+     * if a second successful tap landed in between, because we only undo
+     * our own +1 contribution.
      */
     const incrementStock = useCallback(async (item: GroceryItem) => {
         if (!databaseService) return;
@@ -225,6 +230,10 @@ export function useInventory({
         try {
             await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
+            // Rollback the optimistic +1 so the UI reconverges with DB truth.
+            setItems(prev => prev.map(i =>
+                i.id === item.id ? { ...i, stockQty: Math.max(0, i.stockQty - 1) } : i,
+            ));
             console.error('[useInventory] increment error', e);
             setError({ op: 'updateStock', error: toError(e) });
         }
@@ -233,17 +242,26 @@ export function useInventory({
     const decrementStock = useCallback(async (item: GroceryItem) => {
         if (!databaseService) return;
         let nextQty: number | null = null;
+        let appliedDelta = 0;
         setItems(prev => {
             const current = prev.find(i => i.id === item.id);
             const baseline = current?.stockQty ?? item.stockQty;
             if (baseline <= 0) return prev;
             nextQty = Math.max(0, baseline - 1);
+            appliedDelta = baseline - nextQty; // 1 unless baseline was already 0
             return prev.map(i => (i.id === item.id ? { ...i, stockQty: nextQty as number } : i));
         });
         if (nextQty === null) return;
         try {
             await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
+            // Rollback the optimistic decrement so the UI reconverges with DB truth.
+            const delta = appliedDelta;
+            if (delta > 0) {
+                setItems(prev => prev.map(i =>
+                    i.id === item.id ? { ...i, stockQty: i.stockQty + delta } : i,
+                ));
+            }
             console.error('[useInventory] decrement error', e);
             setError({ op: 'updateStock', error: toError(e) });
         }

--- a/react-native/hooks/useInventory.ts
+++ b/react-native/hooks/useInventory.ts
@@ -89,6 +89,34 @@ export function useInventory({
     const reloadIdRef = useRef(0);
     const isLoadingMoreRef = useRef(false);
 
+    /**
+     * Mirror of `items` that we update alongside `setItems`. Stock-update
+     * handlers read the latest baseline from this ref synchronously instead
+     * of doing it inside a `setItems` updater (which is async, may be
+     * deferred under concurrent rendering, and must not produce side
+     * effects on outer-scope variables).
+     */
+    const itemsRef = useRef<GroceryItem[]>([]);
+    /**
+     * Apply a transform to the items state and keep `itemsRef` in lockstep.
+     * This is the only place that should call `setItems` for in-place edits
+     * so the ref always matches the most recent state we asked React to
+     * commit.
+     */
+    const updateItems = useCallback(
+        (transform: (current: GroceryItem[]) => GroceryItem[]) => {
+            const next = transform(itemsRef.current);
+            itemsRef.current = next;
+            setItems(next);
+        },
+        [],
+    );
+    /** Replace items wholesale (used by reload/loadMore). */
+    const replaceItems = useCallback((next: GroceryItem[]) => {
+        itemsRef.current = next;
+        setItems(next);
+    }, []);
+
     const ready = isDbReady && !!databaseService;
 
     const fetchPage = useCallback(
@@ -112,7 +140,7 @@ export function useInventory({
                 // If a newer reload has been issued in the meantime, drop these
                 // stale results — the newer call will paint authoritative state.
                 if (reloadIdRef.current !== requestId) return;
-                setItems(data);
+                replaceItems(data);
                 offsetRef.current = data.length;
                 setHasMore(data.length >= pageSize);
                 setError(null);
@@ -127,7 +155,7 @@ export function useInventory({
                 }
             }
         },
-        [ready, fetchPage, pageSize],
+        [ready, fetchPage, pageSize, replaceItems],
     );
 
     const loadMore = useCallback(async () => {
@@ -145,7 +173,7 @@ export function useInventory({
             const next = await fetchPage(issuedAtOffset, issuedAtTerm);
             if (reloadIdRef.current !== issuedAtId) return; // superseded
             if (next.length > 0) {
-                setItems(prev => prev.concat(next));
+                updateItems(prev => prev.concat(next));
                 offsetRef.current = issuedAtOffset + next.length;
             }
             setHasMore(next.length >= pageSize);
@@ -157,7 +185,7 @@ export function useInventory({
             isLoadingMoreRef.current = false;
             setIsLoadingMore(false);
         }
-    }, [ready, hasMore, fetchPage, pageSize]);
+    }, [ready, hasMore, fetchPage, pageSize, updateItems]);
 
     // Initial load + reset whenever the database becomes ready.
     useEffect(() => {
@@ -165,11 +193,11 @@ export function useInventory({
             setIsLoading(true);
             reload('');
         } else {
-            setItems([]);
+            replaceItems([]);
             offsetRef.current = 0;
             setHasMore(true);
         }
-    }, [ready, reload]);
+    }, [ready, reload, replaceItems]);
 
     // Debounced search. We wrap reload in a debounced helper that fires on
     // the trailing edge — fast typing won't queue a query per keystroke.
@@ -193,7 +221,6 @@ export function useInventory({
     useCollectionListener(
         registerInventoryListener,
         () => { reload(searchRef.current); },
-        [],
         { enabled: ready, debounceMs: 300, label: 'inventory' },
     );
 
@@ -208,64 +235,61 @@ export function useInventory({
     }, [reload]);
 
     /**
-     * Compute next quantity from the *latest* state inside the functional
-     * setItems updater. This avoids race conditions when the user taps the
-     * +/- button rapidly and the parent's `item` snapshot is stale.
+     * Read the latest baseline quantity from `itemsRef` *before* mutating
+     * state, then apply a pure transform via {@link updateItems}. Doing the
+     * read synchronously (instead of inside a setItems updater) means the
+     * computed `nextQty` is available immediately for the database call —
+     * setItems is asynchronous and React may defer or replay the updater
+     * under concurrent rendering, so it must not produce side effects.
      *
-     * On DB failure we roll back the optimistic delta (not to a captured
-     * absolute) using another functional update — this stays correct even
-     * if a second successful tap landed in between, because we only undo
-     * our own +1 contribution.
+     * Rapid double-tap is still handled correctly because every click reads
+     * the most recent {@link itemsRef.current}, and we update that ref in
+     * lockstep with `setItems` via {@link updateItems}.
+     *
+     * On DB failure we roll back the optimistic delta — not the captured
+     * baseline — so a concurrent successful tap on the same row is not
+     * trampled by our undo.
      */
     const incrementStock = useCallback(async (item: GroceryItem) => {
         if (!databaseService) return;
-        let nextQty: number | null = null;
-        setItems(prev => {
-            const current = prev.find(i => i.id === item.id);
-            const baseline = current?.stockQty ?? item.stockQty;
-            nextQty = baseline + 1;
-            return prev.map(i => (i.id === item.id ? { ...i, stockQty: nextQty as number } : i));
-        });
-        if (nextQty === null) return;
+        const current = itemsRef.current.find(i => i.id === item.id);
+        const baseline = current?.stockQty ?? item.stockQty;
+        const nextQty = baseline + 1;
+        updateItems(prev => prev.map(i =>
+            i.id === item.id ? { ...i, stockQty: nextQty } : i,
+        ));
         try {
             await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
-            // Rollback the optimistic +1 so the UI reconverges with DB truth.
-            setItems(prev => prev.map(i =>
+            updateItems(prev => prev.map(i =>
                 i.id === item.id ? { ...i, stockQty: Math.max(0, i.stockQty - 1) } : i,
             ));
             console.error('[useInventory] increment error', e);
             setError({ op: 'updateStock', error: toError(e) });
         }
-    }, [databaseService]);
+    }, [databaseService, updateItems]);
 
     const decrementStock = useCallback(async (item: GroceryItem) => {
         if (!databaseService) return;
-        let nextQty: number | null = null;
-        let appliedDelta = 0;
-        setItems(prev => {
-            const current = prev.find(i => i.id === item.id);
-            const baseline = current?.stockQty ?? item.stockQty;
-            if (baseline <= 0) return prev;
-            nextQty = Math.max(0, baseline - 1);
-            appliedDelta = baseline - nextQty; // 1 unless baseline was already 0
-            return prev.map(i => (i.id === item.id ? { ...i, stockQty: nextQty as number } : i));
-        });
-        if (nextQty === null) return;
+        const current = itemsRef.current.find(i => i.id === item.id);
+        const baseline = current?.stockQty ?? item.stockQty;
+        if (baseline <= 0) return;
+        const nextQty = Math.max(0, baseline - 1);
+        const appliedDelta = baseline - nextQty; // always 1 here, kept explicit for clarity
+        if (appliedDelta === 0) return;
+        updateItems(prev => prev.map(i =>
+            i.id === item.id ? { ...i, stockQty: nextQty } : i,
+        ));
         try {
             await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
-            // Rollback the optimistic decrement so the UI reconverges with DB truth.
-            const delta = appliedDelta;
-            if (delta > 0) {
-                setItems(prev => prev.map(i =>
-                    i.id === item.id ? { ...i, stockQty: i.stockQty + delta } : i,
-                ));
-            }
+            updateItems(prev => prev.map(i =>
+                i.id === item.id ? { ...i, stockQty: i.stockQty + appliedDelta } : i,
+            ));
             console.error('[useInventory] decrement error', e);
             setError({ op: 'updateStock', error: toError(e) });
         }
-    }, [databaseService]);
+    }, [databaseService, updateItems]);
 
     const createOrder = useCallback(async (item: GroceryItem, qty: number) => {
         if (!databaseService) return false;

--- a/react-native/hooks/useInventory.ts
+++ b/react-native/hooks/useInventory.ts
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DatabaseService } from '@/services/database.service';
+import { GroceryItem } from '@/models/GroceryItem';
+import { debounce } from '@/util/debounce';
+import { useCollectionListener } from './useCollectionListener';
+import { useAppStateRefresh } from './useAppStateRefresh';
+
+const DEFAULT_PAGE_SIZE = 50;
+const SEARCH_DEBOUNCE_MS = 400;
+
+export type InventoryError = {
+    /** Where the failure happened — useful for routing UI messages. */
+    op: 'load' | 'search' | 'updateStock' | 'createOrder';
+    error: Error;
+};
+
+export type UseInventoryResult = {
+    items: GroceryItem[];
+    /** True only on the very first load (used for the full-screen spinner). */
+    isLoading: boolean;
+    /** True when a manual pull-to-refresh is in flight. */
+    isRefreshing: boolean;
+    /** True when an additional page is being appended via {@link loadMore}. */
+    isLoadingMore: boolean;
+    /**
+     * False once a query returned fewer rows than the page size — the host
+     * component should hide the FlatList footer spinner when this is false.
+     */
+    hasMore: boolean;
+    search: string;
+    setSearch: (term: string) => void;
+    error: InventoryError | null;
+    /** Clear the current error. Called by the retry button. */
+    clearError: () => void;
+    /** Pull-to-refresh: rerun the current query from offset 0. */
+    refresh: () => Promise<void>;
+    /** Append the next page. No-op while another page is loading. */
+    loadMore: () => Promise<void>;
+    incrementStock: (item: GroceryItem) => Promise<void>;
+    decrementStock: (item: GroceryItem) => Promise<void>;
+    createOrder: (item: GroceryItem, qty: number) => Promise<boolean>;
+};
+
+type Args = {
+    databaseService: DatabaseService | undefined;
+    isDbReady: boolean;
+    /** Defaults to 50. */
+    pageSize?: number;
+};
+
+/**
+ * Owns inventory data fetching, search, listener wiring, and stock mutations
+ * for the inventory screen. Uses {@link useCollectionListener} for change
+ * detection and {@link useAppStateRefresh} so the screen reloads when the
+ * app returns to the foreground.
+ *
+ * Pagination contract:
+ *   - `refresh()` re-fetches the first page and resets `hasMore`.
+ *   - `loadMore()` appends the next page using LIMIT/OFFSET.
+ *   - When the user types in the search box we always reset to page 0.
+ */
+export function useInventory({
+    databaseService,
+    isDbReady,
+    pageSize = DEFAULT_PAGE_SIZE,
+}: Args): UseInventoryResult {
+    const [items, setItems] = useState<GroceryItem[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+    const [search, setSearchState] = useState('');
+    const [error, setError] = useState<InventoryError | null>(null);
+
+    const offsetRef = useRef(0);
+    const searchRef = useRef('');
+    const isQueryingRef = useRef(false);
+
+    const ready = isDbReady && !!databaseService;
+
+    const fetchPage = useCallback(
+        async (offset: number, term: string): Promise<GroceryItem[]> => {
+            if (!databaseService) return [];
+            return term.length > 0
+                ? databaseService.searchInventory(term, pageSize, offset)
+                : databaseService.getInventoryItems(pageSize, offset);
+        },
+        [databaseService, pageSize],
+    );
+
+    const reload = useCallback(
+        async (term: string, opts: { manual?: boolean } = {}) => {
+            if (!ready) return;
+            if (isQueryingRef.current) return;
+            isQueryingRef.current = true;
+
+            if (opts.manual) setIsRefreshing(true);
+            try {
+                const data = await fetchPage(0, term);
+                setItems(data);
+                offsetRef.current = data.length;
+                setHasMore(data.length >= pageSize);
+                setError(null);
+            } catch (e) {
+                console.error('[useInventory] reload error', e);
+                setError({ op: term ? 'search' : 'load', error: toError(e) });
+            } finally {
+                isQueryingRef.current = false;
+                setIsLoading(false);
+                if (opts.manual) setIsRefreshing(false);
+            }
+        },
+        [ready, fetchPage, pageSize],
+    );
+
+    const loadMore = useCallback(async () => {
+        if (!ready || !hasMore || isLoadingMore || isQueryingRef.current) return;
+        isQueryingRef.current = true;
+        setIsLoadingMore(true);
+        try {
+            const next = await fetchPage(offsetRef.current, searchRef.current);
+            if (next.length > 0) {
+                setItems(prev => prev.concat(next));
+                offsetRef.current += next.length;
+            }
+            setHasMore(next.length >= pageSize);
+        } catch (e) {
+            console.error('[useInventory] loadMore error', e);
+            setError({ op: 'load', error: toError(e) });
+        } finally {
+            isQueryingRef.current = false;
+            setIsLoadingMore(false);
+        }
+    }, [ready, hasMore, isLoadingMore, fetchPage, pageSize]);
+
+    // Initial load + reset whenever the database becomes ready.
+    useEffect(() => {
+        if (ready) {
+            setIsLoading(true);
+            reload('');
+        } else {
+            setItems([]);
+            offsetRef.current = 0;
+            setHasMore(true);
+        }
+    }, [ready, reload]);
+
+    // Debounced search. We wrap reload in a debounced helper that fires on
+    // the trailing edge — fast typing won't queue a query per keystroke.
+    const debouncedSearchRun = useMemo(
+        () => debounce((term: string) => { reload(term); }, SEARCH_DEBOUNCE_MS),
+        [reload],
+    );
+
+    const setSearch = useCallback((term: string) => {
+        setSearchState(term);
+        searchRef.current = term;
+        debouncedSearchRun(term);
+    }, [debouncedSearchRun]);
+
+    // Collection listener: refresh the current page when sync writes land.
+    const registerInventoryListener = useMemo(() => {
+        if (!databaseService) return undefined;
+        return (cb: () => void) => databaseService.addInventoryChangeListener(cb);
+    }, [databaseService]);
+
+    useCollectionListener(
+        registerInventoryListener,
+        () => { reload(searchRef.current); },
+        [],
+        { enabled: ready, debounceMs: 300, label: 'inventory' },
+    );
+
+    // Foreground refresh.
+    useAppStateRefresh(
+        () => { if (ready) reload(searchRef.current); },
+        { enabled: ready },
+    );
+
+    const refresh = useCallback(async () => {
+        await reload(searchRef.current, { manual: true });
+    }, [reload]);
+
+    const incrementStock = useCallback(async (item: GroceryItem) => {
+        if (!databaseService) return;
+        try {
+            await databaseService.updateStockQuantity(item.id, item.stockQty + 1);
+            // Optimistic update; sync listener will reconcile shortly.
+            setItems(prev =>
+                prev.map(i => (i.id === item.id ? { ...i, stockQty: i.stockQty + 1 } : i)),
+            );
+        } catch (e) {
+            console.error('[useInventory] increment error', e);
+            setError({ op: 'updateStock', error: toError(e) });
+        }
+    }, [databaseService]);
+
+    const decrementStock = useCallback(async (item: GroceryItem) => {
+        if (!databaseService || item.stockQty <= 0) return;
+        try {
+            await databaseService.updateStockQuantity(item.id, item.stockQty - 1);
+            setItems(prev =>
+                prev.map(i => (i.id === item.id ? { ...i, stockQty: i.stockQty - 1 } : i)),
+            );
+        } catch (e) {
+            console.error('[useInventory] decrement error', e);
+            setError({ op: 'updateStock', error: toError(e) });
+        }
+    }, [databaseService]);
+
+    const createOrder = useCallback(async (item: GroceryItem, qty: number) => {
+        if (!databaseService) return false;
+        try {
+            await databaseService.createOrder(item, qty);
+            return true;
+        } catch (e) {
+            console.error('[useInventory] createOrder error', e);
+            setError({ op: 'createOrder', error: toError(e) });
+            return false;
+        }
+    }, [databaseService]);
+
+    const clearError = useCallback(() => setError(null), []);
+
+    return {
+        items,
+        isLoading,
+        isRefreshing,
+        isLoadingMore,
+        hasMore,
+        search,
+        setSearch,
+        error,
+        clearError,
+        refresh,
+        loadMore,
+        incrementStock,
+        decrementStock,
+        createOrder,
+    };
+}
+
+function toError(e: unknown): Error {
+    return e instanceof Error ? e : new Error(String(e));
+}

--- a/react-native/hooks/useInventory.ts
+++ b/react-native/hooks/useInventory.ts
@@ -246,9 +246,14 @@ export function useInventory({
      * the most recent {@link itemsRef.current}, and we update that ref in
      * lockstep with `setItems` via {@link updateItems}.
      *
-     * On DB failure we roll back the optimistic delta — not the captured
-     * baseline — so a concurrent successful tap on the same row is not
-     * trampled by our undo.
+     * Rollback strategy: a sync write from another device can land between
+     * our optimistic update and a failed DB write. The change listener
+     * pipes those writes back through `reload()`, which replaces items
+     * entirely. So when we hit the catch block we don't blindly subtract
+     * our delta — we check whether the item still shows the value we
+     * optimistically wrote. If it does, we revert to the captured baseline.
+     * If it doesn't, sync has already authoritative truth in the row and
+     * we leave it alone (touching it would just re-introduce drift).
      */
     const incrementStock = useCallback(async (item: GroceryItem) => {
         if (!databaseService) return;
@@ -261,9 +266,13 @@ export function useInventory({
         try {
             await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
-            updateItems(prev => prev.map(i =>
-                i.id === item.id ? { ...i, stockQty: Math.max(0, i.stockQty - 1) } : i,
-            ));
+            updateItems(prev => prev.map(i => {
+                if (i.id !== item.id) return i;
+                // Only undo if our optimistic write is still the current
+                // value — otherwise a concurrent sync update has taken over.
+                if (i.stockQty !== nextQty) return i;
+                return { ...i, stockQty: Math.max(0, baseline) };
+            }));
             console.error('[useInventory] increment error', e);
             setError({ op: 'updateStock', error: toError(e) });
         }
@@ -275,17 +284,18 @@ export function useInventory({
         const baseline = current?.stockQty ?? item.stockQty;
         if (baseline <= 0) return;
         const nextQty = Math.max(0, baseline - 1);
-        const appliedDelta = baseline - nextQty; // always 1 here, kept explicit for clarity
-        if (appliedDelta === 0) return;
+        if (nextQty === baseline) return;
         updateItems(prev => prev.map(i =>
             i.id === item.id ? { ...i, stockQty: nextQty } : i,
         ));
         try {
             await databaseService.updateStockQuantity(item.id, nextQty);
         } catch (e) {
-            updateItems(prev => prev.map(i =>
-                i.id === item.id ? { ...i, stockQty: i.stockQty + appliedDelta } : i,
-            ));
+            updateItems(prev => prev.map(i => {
+                if (i.id !== item.id) return i;
+                if (i.stockQty !== nextQty) return i;
+                return { ...i, stockQty: baseline };
+            }));
             console.error('[useInventory] decrement error', e);
             setError({ op: 'updateStock', error: toError(e) });
         }

--- a/react-native/hooks/useOrders.ts
+++ b/react-native/hooks/useOrders.ts
@@ -27,17 +27,28 @@ type Args = {
     databaseService: DatabaseService | undefined;
     isDbReady: boolean;
     pageSize?: number;
+    /**
+     * Optional order status to filter by (e.g. "In Review", "Approved",
+     * "Submitted"). When `undefined` or empty, all orders are returned.
+     * The filter is applied at the SQL++ level so that pagination works
+     * across the *filtered* result set — switching tabs to "In Review"
+     * will still surface items that live beyond the first page.
+     */
+    status?: string;
 };
 
 /**
  * Owns orders fetching, listener wiring, and pagination for the orders
- * screen. Filtering by status stays in the screen since it is a local view
- * concern and we don't want to page server-side by status.
+ * screen. The screen passes its currently-selected status filter (if any)
+ * and the hook re-runs the query whenever it changes.
+ *
+ * Concurrency: same "latest request id" pattern as {@link useInventory}.
  */
 export function useOrders({
     databaseService,
     isDbReady,
     pageSize = DEFAULT_PAGE_SIZE,
+    status,
 }: Args): UseOrdersResult {
     const [orders, setOrders] = useState<Order[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -47,67 +58,89 @@ export function useOrders({
     const [error, setError] = useState<OrdersError | null>(null);
 
     const offsetRef = useRef(0);
-    const isQueryingRef = useRef(false);
+    const statusRef = useRef<string | undefined>(status);
+    const reloadIdRef = useRef(0);
+    const isLoadingMoreRef = useRef(false);
 
     const ready = isDbReady && !!databaseService;
 
-    const fetchPage = useCallback(async (offset: number): Promise<Order[]> => {
-        if (!databaseService) return [];
-        return databaseService.getOrders(pageSize, offset);
-    }, [databaseService, pageSize]);
+    const fetchPage = useCallback(
+        async (offset: number, statusFilter: string | undefined): Promise<Order[]> => {
+            if (!databaseService) return [];
+            return databaseService.getOrders(pageSize, offset, statusFilter);
+        },
+        [databaseService, pageSize],
+    );
 
-    const reload = useCallback(async (opts: { manual?: boolean } = {}) => {
-        if (!ready) return;
-        if (isQueryingRef.current) return;
-        isQueryingRef.current = true;
-
-        if (opts.manual) setIsRefreshing(true);
-        try {
-            const data = await fetchPage(0);
-            setOrders(data);
-            offsetRef.current = data.length;
-            setHasMore(data.length >= pageSize);
-            setError(null);
-        } catch (e) {
-            console.error('[useOrders] reload error', e);
-            setError({ op: 'load', error: toError(e) });
-        } finally {
-            isQueryingRef.current = false;
-            setIsLoading(false);
-            if (opts.manual) setIsRefreshing(false);
-        }
-    }, [ready, fetchPage, pageSize]);
+    const reload = useCallback(
+        async (statusFilter: string | undefined, opts: { manual?: boolean } = {}) => {
+            if (!ready) return;
+            const requestId = ++reloadIdRef.current;
+            if (opts.manual) setIsRefreshing(true);
+            try {
+                const data = await fetchPage(0, statusFilter);
+                if (reloadIdRef.current !== requestId) return;
+                setOrders(data);
+                offsetRef.current = data.length;
+                setHasMore(data.length >= pageSize);
+                setError(null);
+            } catch (e) {
+                if (reloadIdRef.current !== requestId) return;
+                console.error('[useOrders] reload error', e);
+                setError({ op: 'load', error: toError(e) });
+            } finally {
+                if (reloadIdRef.current === requestId) {
+                    setIsLoading(false);
+                    if (opts.manual) setIsRefreshing(false);
+                }
+            }
+        },
+        [ready, fetchPage, pageSize],
+    );
 
     const loadMore = useCallback(async () => {
-        if (!ready || !hasMore || isLoadingMore || isQueryingRef.current) return;
-        isQueryingRef.current = true;
+        if (!ready || !hasMore || isLoadingMoreRef.current) return;
+        const issuedAtId = reloadIdRef.current;
+        const issuedAtOffset = offsetRef.current;
+        const issuedAtStatus = statusRef.current;
+
+        isLoadingMoreRef.current = true;
         setIsLoadingMore(true);
         try {
-            const next = await fetchPage(offsetRef.current);
+            const next = await fetchPage(issuedAtOffset, issuedAtStatus);
+            if (reloadIdRef.current !== issuedAtId) return;
             if (next.length > 0) {
                 setOrders(prev => prev.concat(next));
-                offsetRef.current += next.length;
+                offsetRef.current = issuedAtOffset + next.length;
             }
             setHasMore(next.length >= pageSize);
         } catch (e) {
+            if (reloadIdRef.current !== issuedAtId) return;
             console.error('[useOrders] loadMore error', e);
             setError({ op: 'load', error: toError(e) });
         } finally {
-            isQueryingRef.current = false;
+            isLoadingMoreRef.current = false;
             setIsLoadingMore(false);
         }
-    }, [ready, hasMore, isLoadingMore, fetchPage, pageSize]);
+    }, [ready, hasMore, fetchPage, pageSize]);
 
+    // Keep the ref in lock-step with the prop so listener/foreground refreshes
+    // always fetch the currently-selected filter.
+    useEffect(() => {
+        statusRef.current = status;
+    }, [status]);
+
+    // Reload from page 0 when readiness or status changes.
     useEffect(() => {
         if (ready) {
             setIsLoading(true);
-            reload();
+            reload(status);
         } else {
             setOrders([]);
             offsetRef.current = 0;
             setHasMore(true);
         }
-    }, [ready, reload]);
+    }, [ready, reload, status]);
 
     const registerOrdersListener = useMemo(() => {
         if (!databaseService) return undefined;
@@ -116,18 +149,18 @@ export function useOrders({
 
     useCollectionListener(
         registerOrdersListener,
-        () => { reload(); },
+        () => { reload(statusRef.current); },
         [],
         { enabled: ready, debounceMs: 300, label: 'orders' },
     );
 
     useAppStateRefresh(
-        () => { if (ready) reload(); },
+        () => { if (ready) reload(statusRef.current); },
         { enabled: ready },
     );
 
     const refresh = useCallback(async () => {
-        await reload({ manual: true });
+        await reload(statusRef.current, { manual: true });
     }, [reload]);
 
     const clearError = useCallback(() => setError(null), []);

--- a/react-native/hooks/useOrders.ts
+++ b/react-native/hooks/useOrders.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DatabaseService } from '@/services/database.service';
+import { Order } from '@/models/Order';
+import { useCollectionListener } from './useCollectionListener';
+import { useAppStateRefresh } from './useAppStateRefresh';
+
+const DEFAULT_PAGE_SIZE = 50;
+
+export type OrdersError = {
+    op: 'load';
+    error: Error;
+};
+
+export type UseOrdersResult = {
+    orders: Order[];
+    isLoading: boolean;
+    isRefreshing: boolean;
+    isLoadingMore: boolean;
+    hasMore: boolean;
+    error: OrdersError | null;
+    clearError: () => void;
+    refresh: () => Promise<void>;
+    loadMore: () => Promise<void>;
+};
+
+type Args = {
+    databaseService: DatabaseService | undefined;
+    isDbReady: boolean;
+    pageSize?: number;
+};
+
+/**
+ * Owns orders fetching, listener wiring, and pagination for the orders
+ * screen. Filtering by status stays in the screen since it is a local view
+ * concern and we don't want to page server-side by status.
+ */
+export function useOrders({
+    databaseService,
+    isDbReady,
+    pageSize = DEFAULT_PAGE_SIZE,
+}: Args): UseOrdersResult {
+    const [orders, setOrders] = useState<Order[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+    const [error, setError] = useState<OrdersError | null>(null);
+
+    const offsetRef = useRef(0);
+    const isQueryingRef = useRef(false);
+
+    const ready = isDbReady && !!databaseService;
+
+    const fetchPage = useCallback(async (offset: number): Promise<Order[]> => {
+        if (!databaseService) return [];
+        return databaseService.getOrders(pageSize, offset);
+    }, [databaseService, pageSize]);
+
+    const reload = useCallback(async (opts: { manual?: boolean } = {}) => {
+        if (!ready) return;
+        if (isQueryingRef.current) return;
+        isQueryingRef.current = true;
+
+        if (opts.manual) setIsRefreshing(true);
+        try {
+            const data = await fetchPage(0);
+            setOrders(data);
+            offsetRef.current = data.length;
+            setHasMore(data.length >= pageSize);
+            setError(null);
+        } catch (e) {
+            console.error('[useOrders] reload error', e);
+            setError({ op: 'load', error: toError(e) });
+        } finally {
+            isQueryingRef.current = false;
+            setIsLoading(false);
+            if (opts.manual) setIsRefreshing(false);
+        }
+    }, [ready, fetchPage, pageSize]);
+
+    const loadMore = useCallback(async () => {
+        if (!ready || !hasMore || isLoadingMore || isQueryingRef.current) return;
+        isQueryingRef.current = true;
+        setIsLoadingMore(true);
+        try {
+            const next = await fetchPage(offsetRef.current);
+            if (next.length > 0) {
+                setOrders(prev => prev.concat(next));
+                offsetRef.current += next.length;
+            }
+            setHasMore(next.length >= pageSize);
+        } catch (e) {
+            console.error('[useOrders] loadMore error', e);
+            setError({ op: 'load', error: toError(e) });
+        } finally {
+            isQueryingRef.current = false;
+            setIsLoadingMore(false);
+        }
+    }, [ready, hasMore, isLoadingMore, fetchPage, pageSize]);
+
+    useEffect(() => {
+        if (ready) {
+            setIsLoading(true);
+            reload();
+        } else {
+            setOrders([]);
+            offsetRef.current = 0;
+            setHasMore(true);
+        }
+    }, [ready, reload]);
+
+    const registerOrdersListener = useMemo(() => {
+        if (!databaseService) return undefined;
+        return (cb: () => void) => databaseService.addOrdersChangeListener(cb);
+    }, [databaseService]);
+
+    useCollectionListener(
+        registerOrdersListener,
+        () => { reload(); },
+        [],
+        { enabled: ready, debounceMs: 300, label: 'orders' },
+    );
+
+    useAppStateRefresh(
+        () => { if (ready) reload(); },
+        { enabled: ready },
+    );
+
+    const refresh = useCallback(async () => {
+        await reload({ manual: true });
+    }, [reload]);
+
+    const clearError = useCallback(() => setError(null), []);
+
+    return {
+        orders,
+        isLoading,
+        isRefreshing,
+        isLoadingMore,
+        hasMore,
+        error,
+        clearError,
+        refresh,
+        loadMore,
+    };
+}
+
+function toError(e: unknown): Error {
+    return e instanceof Error ? e : new Error(String(e));
+}

--- a/react-native/hooks/useOrders.ts
+++ b/react-native/hooks/useOrders.ts
@@ -150,7 +150,6 @@ export function useOrders({
     useCollectionListener(
         registerOrdersListener,
         () => { reload(statusRef.current); },
-        [],
         { enabled: ready, debounceMs: 300, label: 'orders' },
     );
 

--- a/react-native/hooks/useStoreProfile.ts
+++ b/react-native/hooks/useStoreProfile.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { DatabaseService } from '@/services/database.service';
+import { StoreProfile } from '@/models/StoreProfile';
+import { useCollectionListener } from './useCollectionListener';
+import { useAppStateRefresh } from './useAppStateRefresh';
+
+export type StoreProfileError = {
+    op: 'load';
+    error: Error;
+};
+
+export type UseStoreProfileResult = {
+    profile: StoreProfile | null;
+    isLoading: boolean;
+    isRefreshing: boolean;
+    error: StoreProfileError | null;
+    clearError: () => void;
+    refresh: () => Promise<void>;
+};
+
+type Args = {
+    databaseService: DatabaseService | undefined;
+    isDbReady: boolean;
+};
+
+/**
+ * Loads the current store's profile document and re-fetches it when:
+ *   - the database becomes ready,
+ *   - App Services pushes a change to the profile collection,
+ *   - or the app returns to the foreground.
+ *
+ * The screen using this hook is just a presentation layer.
+ */
+export function useStoreProfile({ databaseService, isDbReady }: Args): UseStoreProfileResult {
+    const [profile, setProfile] = useState<StoreProfile | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [error, setError] = useState<StoreProfileError | null>(null);
+
+    const ready = isDbReady && !!databaseService;
+
+    const load = useCallback(async (opts: { manual?: boolean } = {}) => {
+        if (!ready) return;
+        if (opts.manual) setIsRefreshing(true);
+        try {
+            const data = await databaseService!.getStoreProfile();
+            setProfile(data);
+            setError(null);
+        } catch (e) {
+            console.error('[useStoreProfile] load error', e);
+            setError({ op: 'load', error: toError(e) });
+        } finally {
+            setIsLoading(false);
+            if (opts.manual) setIsRefreshing(false);
+        }
+    }, [ready, databaseService]);
+
+    useEffect(() => {
+        if (ready) {
+            setIsLoading(true);
+            load();
+        } else {
+            setProfile(null);
+        }
+    }, [ready, load]);
+
+    const registerProfileListener = useMemo(() => {
+        if (!databaseService) return undefined;
+        return (cb: () => void) => databaseService.addProfileChangeListener(cb);
+    }, [databaseService]);
+
+    useCollectionListener(
+        registerProfileListener,
+        () => { load(); },
+        [],
+        { enabled: ready, debounceMs: 300, label: 'profile' },
+    );
+
+    useAppStateRefresh(
+        () => { if (ready) load(); },
+        { enabled: ready },
+    );
+
+    const refresh = useCallback(async () => {
+        await load({ manual: true });
+    }, [load]);
+
+    const clearError = useCallback(() => setError(null), []);
+
+    return { profile, isLoading, isRefreshing, error, clearError, refresh };
+}
+
+function toError(e: unknown): Error {
+    return e instanceof Error ? e : new Error(String(e));
+}

--- a/react-native/hooks/useStoreProfile.ts
+++ b/react-native/hooks/useStoreProfile.ts
@@ -72,7 +72,6 @@ export function useStoreProfile({ databaseService, isDbReady }: Args): UseStoreP
     useCollectionListener(
         registerProfileListener,
         () => { load(); },
-        [],
         { enabled: ready, debounceMs: 300, label: 'profile' },
     );
 

--- a/react-native/providers/DatabaseContextType.ts
+++ b/react-native/providers/DatabaseContextType.ts
@@ -4,4 +4,15 @@ export type DatabaseContextType = {
     databaseService: DatabaseService;
     syncStatus: SyncStatus;
     isDbReady: boolean;
+    /**
+     * Error from {@link DatabaseService.initializeDatabase}. Set when the
+     * database failed to open or replicator setup threw. UI should show a
+     * banner with a retry button when this is non-null.
+     */
+    initError: Error | null;
+    /**
+     * Re-runs database initialization. Useful for retry buttons after an
+     * initError is shown.
+     */
+    retryInit: () => void;
 };

--- a/react-native/providers/DatabaseProvider.tsx
+++ b/react-native/providers/DatabaseProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, ReactNode, useMemo, useEffect } from 'react';
+import React, { useState, useRef, ReactNode, useMemo, useEffect, useCallback } from 'react';
 import { DatabaseService, SyncStatus } from '@/services/database.service';
 import DatabaseContext from './DatabaseContext';
 import { StoreConfig } from '@/models/AppConfig';
@@ -12,42 +12,59 @@ const DatabaseProvider: React.FC<DatabaseProviderProps> = ({ children, storeConf
     const dbServiceRef = useRef<DatabaseService>(new DatabaseService());
     const [syncStatus, setSyncStatus] = useState<SyncStatus>('stopped');
     const [isDbReady, setIsDbReady] = useState(false);
+    const [initError, setInitError] = useState<Error | null>(null);
+    // Bumping this counter triggers re-init via the effect dependency array.
+    const [retryCount, setRetryCount] = useState(0);
 
     useEffect(() => {
         const dbService = dbServiceRef.current;
+        let cancelled = false;
 
         const initialize = async () => {
+            // Reset state so a retry shows the spinner instead of a stale error.
+            setIsDbReady(false);
+            setInitError(null);
+
             try {
-                // Register sync status callback before initializing
                 dbService.onSyncStatusChange((status) => {
-                    setSyncStatus(status);
+                    if (!cancelled) setSyncStatus(status);
                 });
 
                 await dbService.initializeDatabase(storeConfig);
+                if (cancelled) return;
                 setIsDbReady(true);
                 console.log('[DatabaseProvider] Database initialized successfully');
             } catch (error) {
                 console.error('[DatabaseProvider] Failed to initialize database:', error);
+                if (!cancelled) {
+                    setInitError(error instanceof Error ? error : new Error(String(error)));
+                }
             }
         };
 
         initialize();
 
-        // Cleanup on unmount (logout)
         return () => {
+            cancelled = true;
             dbService.closeDatabase().catch(e =>
                 console.error('[DatabaseProvider] Cleanup error:', e)
             );
         };
-    }, [storeConfig]);
+    }, [storeConfig, retryCount]);
+
+    const retryInit = useCallback(() => {
+        setRetryCount(c => c + 1);
+    }, []);
 
     const value = useMemo(
         () => ({
             databaseService: dbServiceRef.current,
             syncStatus,
             isDbReady,
+            initError,
+            retryInit,
         }),
-        [syncStatus, isDbReady],
+        [syncStatus, isDbReady, initError, retryInit],
     );
 
     return (

--- a/react-native/providers/DatabaseProvider.tsx
+++ b/react-native/providers/DatabaseProvider.tsx
@@ -15,6 +15,14 @@ const DatabaseProvider: React.FC<DatabaseProviderProps> = ({ children, storeConf
     const [initError, setInitError] = useState<Error | null>(null);
     // Bumping this counter triggers re-init via the effect dependency array.
     const [retryCount, setRetryCount] = useState(0);
+    /**
+     * Tracks the last `closeDatabase()` promise so the next initialization
+     * attempt can wait for it to settle before opening the database again.
+     * Without this, retries (or rapid storeConfig swaps) could begin opening
+     * a fresh database while the previous instance is still being closed,
+     * which can fail with file-locking errors on iOS/Android.
+     */
+    const closePromiseRef = useRef<Promise<void>>(Promise.resolve());
 
     useEffect(() => {
         const dbService = dbServiceRef.current;
@@ -24,6 +32,17 @@ const DatabaseProvider: React.FC<DatabaseProviderProps> = ({ children, storeConf
             // Reset state so a retry shows the spinner instead of a stale error.
             setIsDbReady(false);
             setInitError(null);
+
+            // Wait for any in-flight close from the previous effect run
+            // before opening the database again. The cleanup callback can't
+            // be async, so we hand its promise off via a ref and await it
+            // here at the start of the next effect.
+            try {
+                await closePromiseRef.current;
+            } catch {
+                /* close errors are already logged in the cleanup callback */
+            }
+            if (cancelled) return;
 
             try {
                 dbService.onSyncStatusChange((status) => {
@@ -46,9 +65,10 @@ const DatabaseProvider: React.FC<DatabaseProviderProps> = ({ children, storeConf
 
         return () => {
             cancelled = true;
-            dbService.closeDatabase().catch(e =>
-                console.error('[DatabaseProvider] Cleanup error:', e)
-            );
+            // Capture the close promise so the next effect run can await it.
+            closePromiseRef.current = dbService.closeDatabase().catch(e => {
+                console.error('[DatabaseProvider] Cleanup error:', e);
+            });
         };
     }, [storeConfig, retryCount]);
 

--- a/react-native/services/database.service.ts
+++ b/react-native/services/database.service.ts
@@ -320,14 +320,13 @@ export class DatabaseService {
         if (!this.database || !this.storeConfig) return [];
         const scope = this.storeConfig.scopeName;
         let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${APP_CONFIG.collections.inventory}\` ORDER BY name`;
-        const usePagination = typeof limit === 'number' && limit > 0;
-        if (usePagination) {
+        if (typeof limit === 'number' && limit > 0) {
             queryStr += ` LIMIT $limit OFFSET $offset`;
         }
         const query = this.database.createQuery(queryStr);
-        if (usePagination) {
+        if (typeof limit === 'number' && limit > 0) {
             const params = new Parameters();
-            params.setInt('limit', Math.floor(limit as number));
+            params.setInt('limit', Math.floor(limit));
             params.setInt('offset', Math.max(0, Math.floor(offset)));
             query.parameters = params;
         }
@@ -464,23 +463,23 @@ export class DatabaseService {
         const scope = this.storeConfig.scopeName;
         const col = APP_CONFIG.collections.orders;
         let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\``;
-        const useStatus = typeof status === 'string' && status.length > 0;
-        if (useStatus) {
+        if (typeof status === 'string' && status.length > 0) {
             queryStr += ` WHERE orderStatus = $status`;
         }
         queryStr += ` ORDER BY orderDate DESC`;
-        const usePagination = typeof limit === 'number' && limit > 0;
-        if (usePagination) {
+        if (typeof limit === 'number' && limit > 0) {
             queryStr += ` LIMIT $limit OFFSET $offset`;
         }
         const query = this.database.createQuery(queryStr);
-        if (useStatus || usePagination) {
+        const hasStatus = typeof status === 'string' && status.length > 0;
+        const hasPagination = typeof limit === 'number' && limit > 0;
+        if (hasStatus || hasPagination) {
             const params = new Parameters();
-            if (useStatus) {
-                params.setString('status', status as string);
+            if (typeof status === 'string' && status.length > 0) {
+                params.setString('status', status);
             }
-            if (usePagination) {
-                params.setInt('limit', Math.floor(limit as number));
+            if (typeof limit === 'number' && limit > 0) {
+                params.setInt('limit', Math.floor(limit));
                 params.setInt('offset', Math.max(0, Math.floor(offset)));
             }
             query.parameters = params;

--- a/react-native/services/database.service.ts
+++ b/react-native/services/database.service.ts
@@ -229,25 +229,45 @@ export class DatabaseService {
     // ─── Inventory Queries ─────────────────────────────────────
 
     /**
-     * Returns all inventory items in the current store scope.
+     * Returns inventory items in the current store scope, ordered by name.
+     *
+     * Pagination is opt-in: when {@code limit} is undefined the query returns
+     * the full collection (legacy behaviour). When provided, the query uses
+     * SQL++ LIMIT/OFFSET so pages can be loaded incrementally.
      */
-    public async getInventoryItems(): Promise<GroceryItem[]> {
+    public async getInventoryItems(
+        limit?: number,
+        offset: number = 0,
+    ): Promise<GroceryItem[]> {
         if (!this.database || !this.storeConfig) return [];
         const scope = this.storeConfig.scopeName;
-        const queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${APP_CONFIG.collections.inventory}\``;
+        let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${APP_CONFIG.collections.inventory}\` ORDER BY name`;
+        if (typeof limit === 'number' && limit > 0) {
+            queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
+        }
         const results = await this.database.createQuery(queryStr).execute();
         return this.mapInventoryResults(results);
     }
 
     /**
      * Search inventory items by name, category, or brand using LIKE.
+     * Same pagination contract as {@link getInventoryItems}.
      */
-    public async searchInventory(searchTerm: string): Promise<GroceryItem[]> {
+    public async searchInventory(
+        searchTerm: string,
+        limit?: number,
+        offset: number = 0,
+    ): Promise<GroceryItem[]> {
         if (!this.database || !this.storeConfig) return [];
         const scope = this.storeConfig.scopeName;
         const col = APP_CONFIG.collections.inventory;
-        const term = searchTerm.toLowerCase();
-        const queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\` WHERE LOWER(name) LIKE '%${term}%' OR LOWER(type) LIKE '%${term}%' OR LOWER(brand) LIKE '%${term}%'`;
+        // Escape single quotes to keep the LIKE pattern safe — SQL++ does not
+        // expose parameterised queries here, so we sanitize the user input.
+        const term = searchTerm.toLowerCase().replace(/'/g, "''");
+        let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\` WHERE LOWER(name) LIKE '%${term}%' OR LOWER(type) LIKE '%${term}%' OR LOWER(brand) LIKE '%${term}%' ORDER BY name`;
+        if (typeof limit === 'number' && limit > 0) {
+            queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
+        }
         const results = await this.database.createQuery(queryStr).execute();
         return this.mapInventoryResults(results);
     }
@@ -313,13 +333,21 @@ export class DatabaseService {
     // ─── Orders Queries ────────────────────────────────────────
 
     /**
-     * Returns all orders in the current store scope, newest first.
+     * Returns orders in the current store scope, newest first.
+     *
+     * Pagination is opt-in (see {@link getInventoryItems}).
      */
-    public async getOrders(): Promise<Order[]> {
+    public async getOrders(
+        limit?: number,
+        offset: number = 0,
+    ): Promise<Order[]> {
         if (!this.database || !this.storeConfig) return [];
         const scope = this.storeConfig.scopeName;
         const col = APP_CONFIG.collections.orders;
-        const queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\` ORDER BY orderDate DESC`;
+        let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\` ORDER BY orderDate DESC`;
+        if (typeof limit === 'number' && limit > 0) {
+            queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
+        }
         const results = await this.database.createQuery(queryStr).execute();
         return this.mapOrderResults(results);
     }
@@ -424,6 +452,16 @@ export class DatabaseService {
      */
     public async addOrdersChangeListener(callback: () => void): Promise<any> {
         return this.ordersCollection?.addChangeListener(() => {
+            callback();
+        });
+    }
+
+    /**
+     * Add a change listener for the profile collection. Used by the profile
+     * screen so it refreshes when App Services pushes a new profile doc.
+     */
+    public async addProfileChangeListener(callback: () => void): Promise<any> {
+        return this.profileCollection?.addChangeListener(() => {
             callback();
         });
     }

--- a/react-native/services/database.service.ts
+++ b/react-native/services/database.service.ts
@@ -12,6 +12,7 @@ import {
     LogLevel,
     LogSinks,
     MutableDocument,
+    Parameters,
     Replicator,
     ReplicatorActivityLevel,
     ReplicatorConfiguration,
@@ -34,6 +35,36 @@ function safeNumber(val: any): number {
     if (val === null || val === undefined) return 0;
     const n = Number(val);
     return isNaN(n) ? 0 : n;
+}
+
+/**
+ * Convert a free-text search input into a Couchbase Lite FTS query
+ * expression. Each whitespace-delimited token becomes a prefix match so
+ * partial typing matches as you go ("mil" -> "milk*"). FTS operator
+ * characters (quote, parentheses, asterisk, colon, AND/OR/NOT keywords,
+ * etc.) are stripped from the user input before the prefix is appended,
+ * so user-supplied text can never escape into the FTS grammar.
+ *
+ * Returns `null` when the cleaned input has no usable tokens — the caller
+ * should treat that the same as "no search filter applied".
+ */
+function buildFtsExpression(input: string): string | null {
+    if (typeof input !== 'string') return null;
+    const cleaned = input
+        .toLowerCase()
+        // Replace anything that isn't a letter, digit, or whitespace with a
+        // space. This handily strips ASCII FTS operators ('"*?:()[]') and
+        // also keeps the rule simple enough to be safe against unexpected
+        // characters in user input.
+        .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+        .trim();
+    if (cleaned.length === 0) return null;
+
+    const tokens = cleaned.split(/\s+/).filter(t => t.length > 0);
+    if (tokens.length === 0) return null;
+    // Each token gets a prefix-wildcard match. Tokens are space-separated,
+    // which CBL FTS treats as an OR of the individual matches by default.
+    return tokens.map(t => `${t}*`).join(' ');
 }
 
 /**
@@ -160,10 +191,23 @@ export class DatabaseService {
         );
         await this.inventoryCollection.createIndex('idxInventoryNameType', nameIndex);
 
-        // Full-text search index on name for search functionality
+        // Full-text search index. We include `type` (the category field) so
+        // searches like "dairy" or "bakery" still light up the FTS index
+        // instead of falling back to a full table scan.
+        //
+        // The original index only covered `name` and `brand`. Drop it first
+        // so existing local databases get rebuilt with the new schema —
+        // createIndex on its own won't update an existing index definition.
+        try {
+            await this.inventoryCollection.deleteIndex('idxInventoryFTS');
+        } catch (e) {
+            // No-op: index didn't exist on this device yet.
+        }
         const ftsName = FullTextIndexItem.property('name');
         const ftsBrand = FullTextIndexItem.property('brand');
-        const ftsIndex = IndexBuilder.fullTextIndex(ftsName, ftsBrand).setIgnoreAccents(true);
+        const ftsType = FullTextIndexItem.property('type');
+        const ftsIndex = IndexBuilder.fullTextIndex(ftsName, ftsBrand, ftsType)
+            .setIgnoreAccents(true);
         await this.inventoryCollection.createIndex('idxInventoryFTS', ftsIndex);
 
         // Orders index
@@ -250,7 +294,18 @@ export class DatabaseService {
     }
 
     /**
-     * Search inventory items by name, category, or brand using LIKE.
+     * Search inventory items by name, brand, or category. Uses the
+     * `idxInventoryFTS` Full-Text Search index via the `MATCH` operator so
+     * the query is index-backed instead of doing a full table scan, and
+     * passes the user input as a bound `$term` parameter to avoid string
+     * interpolation entirely.
+     *
+     * The user's input is tokenised on whitespace and each token is
+     * suffixed with `*` so prefix matching feels familiar (typing "mil"
+     * matches "milk", "milkshake", "milky way"). Special FTS operator
+     * characters are stripped so we don't accidentally feed the user's
+     * `AND`/`OR`/quote characters straight into the FTS expression parser.
+     *
      * Same pagination contract as {@link getInventoryItems}.
      */
     public async searchInventory(
@@ -259,16 +314,29 @@ export class DatabaseService {
         offset: number = 0,
     ): Promise<GroceryItem[]> {
         if (!this.database || !this.storeConfig) return [];
+
+        const ftsExpression = buildFtsExpression(searchTerm);
+        // An empty/all-punctuation search term shouldn't return everything —
+        // fall back to the unfiltered paginated query so callers still get
+        // sensible results.
+        if (ftsExpression === null) {
+            return this.getInventoryItems(limit, offset);
+        }
+
         const scope = this.storeConfig.scopeName;
         const col = APP_CONFIG.collections.inventory;
-        // Escape single quotes to keep the LIKE pattern safe — SQL++ does not
-        // expose parameterised queries here, so we sanitize the user input.
-        const term = searchTerm.toLowerCase().replace(/'/g, "''");
-        let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\` WHERE LOWER(name) LIKE '%${term}%' OR LOWER(type) LIKE '%${term}%' OR LOWER(brand) LIKE '%${term}%' ORDER BY name`;
+        let queryStr =
+            `SELECT META().id, * FROM \`${scope}\`.\`${col}\` ` +
+            `WHERE MATCH(idxInventoryFTS, $term) ` +
+            `ORDER BY RANK(idxInventoryFTS), name`;
         if (typeof limit === 'number' && limit > 0) {
             queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
         }
-        const results = await this.database.createQuery(queryStr).execute();
+        const query = this.database.createQuery(queryStr);
+        const params = new Parameters();
+        params.setString('term', ftsExpression);
+        query.parameters = params;
+        const results = await query.execute();
         return this.mapInventoryResults(results);
     }
 
@@ -335,20 +403,36 @@ export class DatabaseService {
     /**
      * Returns orders in the current store scope, newest first.
      *
-     * Pagination is opt-in (see {@link getInventoryItems}).
+     * Pagination is opt-in (see {@link getInventoryItems}). When `status` is
+     * provided the filter is applied at the SQL++ level so that LIMIT/OFFSET
+     * paginates the *filtered* result set — without it, an "In Review" filter
+     * applied client-side on a single page would falsely show "no orders" if
+     * none of the first {@code limit} orders happened to match.
      */
     public async getOrders(
         limit?: number,
         offset: number = 0,
+        status?: string,
     ): Promise<Order[]> {
         if (!this.database || !this.storeConfig) return [];
         const scope = this.storeConfig.scopeName;
         const col = APP_CONFIG.collections.orders;
-        let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\` ORDER BY orderDate DESC`;
+        let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${col}\``;
+        const useStatus = typeof status === 'string' && status.length > 0;
+        if (useStatus) {
+            queryStr += ` WHERE orderStatus = $status`;
+        }
+        queryStr += ` ORDER BY orderDate DESC`;
         if (typeof limit === 'number' && limit > 0) {
             queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
         }
-        const results = await this.database.createQuery(queryStr).execute();
+        const query = this.database.createQuery(queryStr);
+        if (useStatus) {
+            const params = new Parameters();
+            params.setString('status', status as string);
+            query.parameters = params;
+        }
+        const results = await query.execute();
         return this.mapOrderResults(results);
     }
 

--- a/react-native/services/database.service.ts
+++ b/react-native/services/database.service.ts
@@ -29,6 +29,17 @@ import uuid from 'react-native-uuid';
 export type SyncStatus = 'idle' | 'busy' | 'connecting' | 'offline' | 'stopped';
 
 /**
+ * FTS index schema version. The index name embeds this so we can roll out a
+ * new field set (e.g. adding `type`) by bumping the suffix — devices that
+ * already have the previous version will see the new name is missing,
+ * create it, and the obsolete index will be removed once on first run.
+ *
+ * Bump this whenever the FTS index's covered fields or options change.
+ */
+const INVENTORY_FTS_INDEX_VERSION = 2;
+const INVENTORY_FTS_INDEX_NAME = `idxInventoryFTSv${INVENTORY_FTS_INDEX_VERSION}`;
+
+/**
  * Safely converts a value to a number. Returns 0 for null/undefined/NaN/non-numeric.
  */
 function safeNumber(val: any): number {
@@ -195,20 +206,40 @@ export class DatabaseService {
         // searches like "dairy" or "bakery" still light up the FTS index
         // instead of falling back to a full table scan.
         //
-        // The original index only covered `name` and `brand`. Drop it first
-        // so existing local databases get rebuilt with the new schema —
-        // createIndex on its own won't update an existing index definition.
-        try {
-            await this.inventoryCollection.deleteIndex('idxInventoryFTS');
-        } catch (e) {
-            // No-op: index didn't exist on this device yet.
+        // We embed a schema version in the index name so we don't have to
+        // pay the drop-and-rebuild cost on every launch — `createIndex` is
+        // idempotent for the *same* index name, but it cannot detect a
+        // changed definition. The version bump approach lets us roll out
+        // schema changes safely:
+        //
+        //   1. Read the current set of index names from the collection.
+        //   2. If the versioned name is already present, leave it alone.
+        //   3. Otherwise create it (cheap on a fresh DB, one-time cost on
+        //      upgrades).
+        //   4. Sweep up any older versions / the legacy unversioned index
+        //      so they don't keep consuming write amplification.
+        const existingIndexes = await this.inventoryCollection.indexes();
+        if (!existingIndexes.includes(INVENTORY_FTS_INDEX_NAME)) {
+            const ftsName = FullTextIndexItem.property('name');
+            const ftsBrand = FullTextIndexItem.property('brand');
+            const ftsType = FullTextIndexItem.property('type');
+            const ftsIndex = IndexBuilder.fullTextIndex(ftsName, ftsBrand, ftsType)
+                .setIgnoreAccents(true);
+            await this.inventoryCollection.createIndex(INVENTORY_FTS_INDEX_NAME, ftsIndex);
+            console.debug(`[GroceryDB] Created FTS index: ${INVENTORY_FTS_INDEX_NAME}`);
         }
-        const ftsName = FullTextIndexItem.property('name');
-        const ftsBrand = FullTextIndexItem.property('brand');
-        const ftsType = FullTextIndexItem.property('type');
-        const ftsIndex = IndexBuilder.fullTextIndex(ftsName, ftsBrand, ftsType)
-            .setIgnoreAccents(true);
-        await this.inventoryCollection.createIndex('idxInventoryFTS', ftsIndex);
+        // One-time cleanup of legacy / superseded FTS indexes.
+        for (const stale of existingIndexes) {
+            if (stale === INVENTORY_FTS_INDEX_NAME) continue;
+            if (stale === 'idxInventoryFTS' || /^idxInventoryFTSv\d+$/.test(stale)) {
+                try {
+                    await this.inventoryCollection.deleteIndex(stale);
+                    console.debug(`[GroceryDB] Removed stale FTS index: ${stale}`);
+                } catch (e) {
+                    console.warn(`[GroceryDB] Failed to delete stale index ${stale}`, e);
+                }
+            }
+        }
 
         // Orders index
         const orderIndex = IndexBuilder.valueIndex(
@@ -286,10 +317,18 @@ export class DatabaseService {
         if (!this.database || !this.storeConfig) return [];
         const scope = this.storeConfig.scopeName;
         let queryStr = `SELECT META().id, * FROM \`${scope}\`.\`${APP_CONFIG.collections.inventory}\` ORDER BY name`;
-        if (typeof limit === 'number' && limit > 0) {
-            queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
+        const usePagination = typeof limit === 'number' && limit > 0;
+        if (usePagination) {
+            queryStr += ` LIMIT $limit OFFSET $offset`;
         }
-        const results = await this.database.createQuery(queryStr).execute();
+        const query = this.database.createQuery(queryStr);
+        if (usePagination) {
+            const params = new Parameters();
+            params.setInt('limit', Math.floor(limit as number));
+            params.setInt('offset', Math.max(0, Math.floor(offset)));
+            query.parameters = params;
+        }
+        const results = await query.execute();
         return this.mapInventoryResults(results);
     }
 
@@ -327,14 +366,18 @@ export class DatabaseService {
         const col = APP_CONFIG.collections.inventory;
         let queryStr =
             `SELECT META().id, * FROM \`${scope}\`.\`${col}\` ` +
-            `WHERE MATCH(idxInventoryFTS, $term) ` +
-            `ORDER BY RANK(idxInventoryFTS), name`;
+            `WHERE MATCH(${INVENTORY_FTS_INDEX_NAME}, $term) ` +
+            `ORDER BY RANK(${INVENTORY_FTS_INDEX_NAME}), name`;
         if (typeof limit === 'number' && limit > 0) {
-            queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
+            queryStr += ` LIMIT $limit OFFSET $offset`;
         }
         const query = this.database.createQuery(queryStr);
         const params = new Parameters();
         params.setString('term', ftsExpression);
+        if (typeof limit === 'number' && limit > 0) {
+            params.setInt('limit', Math.floor(limit));
+            params.setInt('offset', Math.max(0, Math.floor(offset)));
+        }
         query.parameters = params;
         const results = await query.execute();
         return this.mapInventoryResults(results);
@@ -423,13 +466,20 @@ export class DatabaseService {
             queryStr += ` WHERE orderStatus = $status`;
         }
         queryStr += ` ORDER BY orderDate DESC`;
-        if (typeof limit === 'number' && limit > 0) {
-            queryStr += ` LIMIT ${Math.floor(limit)} OFFSET ${Math.max(0, Math.floor(offset))}`;
+        const usePagination = typeof limit === 'number' && limit > 0;
+        if (usePagination) {
+            queryStr += ` LIMIT $limit OFFSET $offset`;
         }
         const query = this.database.createQuery(queryStr);
-        if (useStatus) {
+        if (useStatus || usePagination) {
             const params = new Parameters();
-            params.setString('status', status as string);
+            if (useStatus) {
+                params.setString('status', status as string);
+            }
+            if (usePagination) {
+                params.setInt('limit', Math.floor(limit as number));
+                params.setInt('offset', Math.max(0, Math.floor(offset)));
+            }
             query.parameters = params;
         }
         const results = await query.execute();

--- a/react-native/services/database.service.ts
+++ b/react-native/services/database.service.ts
@@ -73,13 +73,12 @@ function buildFtsExpression(input: string): string | null {
 
     const tokens = cleaned.split(/\s+/).filter(t => t.length > 0);
     if (tokens.length === 0) return null;
-    // Each token gets a prefix-wildcard match. Couchbase Lite FTS treats
-    // adjacent tokens as an implicit AND (a row must match every token),
-    // which feels too strict for an inventory search box where the user
-    // is typing free text. Join with an explicit `OR` so partial inputs
-    // like "milk bread" still surface rows that match either word — the
-    // RANK() ordering in the caller pushes multi-token matches to the top.
-    return tokens.map(t => `${t}*`).join(' OR ');
+    // Each token gets a prefix-wildcard match. Tokens are space-separated,
+    // which Couchbase Lite FTS interprets as an implicit AND — every token
+    // must match. For an inventory search box that's the more useful
+    // semantic: typing "red apple" should narrow the list to red apples
+    // rather than returning every red item plus every apple.
+    return tokens.map(t => `${t}*`).join(' ');
 }
 
 /**

--- a/react-native/services/database.service.ts
+++ b/react-native/services/database.service.ts
@@ -73,9 +73,13 @@ function buildFtsExpression(input: string): string | null {
 
     const tokens = cleaned.split(/\s+/).filter(t => t.length > 0);
     if (tokens.length === 0) return null;
-    // Each token gets a prefix-wildcard match. Tokens are space-separated,
-    // which CBL FTS treats as an OR of the individual matches by default.
-    return tokens.map(t => `${t}*`).join(' ');
+    // Each token gets a prefix-wildcard match. Couchbase Lite FTS treats
+    // adjacent tokens as an implicit AND (a row must match every token),
+    // which feels too strict for an inventory search box where the user
+    // is typing free text. Join with an explicit `OR` so partial inputs
+    // like "milk bread" still surface rows that match either word — the
+    // RANK() ordering in the caller pushes multi-token matches to the top.
+    return tokens.map(t => `${t}*`).join(' OR ');
 }
 
 /**


### PR DESCRIPTION
Resolves issues #40-#46:

- #44 useCollectionListener: shared hook handles async-cancellation, debouncing, and listener cleanup so each screen no longer rolls its own ref-juggling around addInventoryChangeListener et al.

- #45 useAppStateRefresh: re-runs the screen's loader when the app returns to the foreground (with a 2s minimum-background guard so quick app-switches don't thrash the DB).

- #46 pagination: getInventoryItems / searchInventory / getOrders now accept optional limit/offset; useInventory and useOrders expose loadMore + hasMore + isLoadingMore for FlatList infinite scroll.

- #41 useInventory: owns search, listener wiring, foreground refresh, pagination, optimistic stock updates, and order creation. The inventory screen is now a presentation layer.

- #42 useOrders: same shape, status filter stays as a local view concern in the screen.

- #43 useStoreProfile: profile screen no longer manages loading or refresh; new addProfileChangeListener() helper added to the service.

- #40 visible errors: every screen renders an ErrorBanner with a Retry / Dismiss control. DatabaseProvider now exposes initError + retryInit so a CBL init failure no longer leaves the user stuck on a blank tab. Hooks expose typed { op, error } values so screens can show contextual titles ("Could not load inventory", "Could not update stock", etc.) instead of silently swallowing errors.